### PR TITLE
Use Levenshtein distance to score documents in fuzzy term queries

### DIFF
--- a/src/query/automaton_weight.rs
+++ b/src/query/automaton_weight.rs
@@ -1,14 +1,17 @@
+use crate::query::fuzzy_query::DfaWrapper;
+use crate::query::score_combiner::SumCombiner;
+use crate::query::Union;
+use std::any::{Any, TypeId};
 use std::io;
 use std::sync::Arc;
 
-use common::BitSet;
 use tantivy_fst::Automaton;
 
 use super::phrase_prefix_query::prefix_end;
 use crate::core::SegmentReader;
-use crate::query::{BitSetDocSet, ConstScorer, Explanation, Scorer, Weight};
+use crate::query::{ConstScorer, Explanation, Scorer, Weight};
 use crate::schema::{Field, IndexRecordOption};
-use crate::termdict::{TermDictionary, TermStreamer};
+use crate::termdict::{TermDictionary, TermWithStateStreamer};
 use crate::{DocId, Score, TantivyError};
 
 /// A weight struct for Fuzzy Term and Regex Queries
@@ -51,9 +54,10 @@ where
     fn automaton_stream<'a>(
         &'a self,
         term_dict: &'a TermDictionary,
-    ) -> io::Result<TermStreamer<'a, &'a A>> {
+    ) -> io::Result<TermWithStateStreamer<'a, &'a A>> {
         let automaton: &A = &self.automaton;
-        let mut term_stream_builder = term_dict.search(automaton);
+        // let mut term_stream_builder = term_dict.search(automaton);
+        let mut term_stream_builder = term_dict.search_with_state(automaton);
 
         if let Some(json_path_bytes) = &self.json_path_bytes {
             term_stream_builder = term_stream_builder.ge(json_path_bytes);
@@ -72,40 +76,51 @@ where
     A::State: Clone,
 {
     fn scorer(&self, reader: &SegmentReader, boost: Score) -> crate::Result<Box<dyn Scorer>> {
-        let max_doc = reader.max_doc();
-        let mut doc_bitset = BitSet::with_max_value(max_doc);
         let inverted_index = reader.inverted_index(self.field)?;
         let term_dict = inverted_index.terms();
         let mut term_stream = self.automaton_stream(term_dict)?;
-        while term_stream.advance() {
-            let term_info = term_stream.value();
-            let mut block_segment_postings = inverted_index
-                .read_block_postings_from_terminfo(term_info, IndexRecordOption::Basic)?;
-            loop {
-                let docs = block_segment_postings.docs();
-                if docs.is_empty() {
-                    break;
-                }
-                for &doc in docs {
-                    doc_bitset.insert(doc);
-                }
-                block_segment_postings.advance();
-            }
+
+        let mut scorers = vec![];
+        while let Some((_term, term_info, state)) = term_stream.next() {
+            let score = automaton_score(self.automaton.as_ref(), state);
+            let segment_postings =
+                inverted_index.read_postings_from_terminfo(term_info, IndexRecordOption::Basic)?;
+            let scorer = ConstScorer::new(segment_postings, boost * score);
+            scorers.push(scorer);
         }
-        let doc_bitset = BitSetDocSet::from(doc_bitset);
-        let const_scorer = ConstScorer::new(doc_bitset, boost);
-        Ok(Box::new(const_scorer))
+
+        let scorer = Union::build(scorers, SumCombiner::default);
+        Ok(Box::new(scorer))
     }
 
     fn explain(&self, reader: &SegmentReader, doc: DocId) -> crate::Result<Explanation> {
         let mut scorer = self.scorer(reader, 1.0)?;
         if scorer.seek(doc) == doc {
-            Ok(Explanation::new("AutomatonScorer", 1.0))
+            Ok(Explanation::new("AutomatonScorer", scorer.score()))
         } else {
             Err(TantivyError::InvalidArgument(
                 "Document does not exist".to_string(),
             ))
         }
+    }
+}
+
+fn automaton_score<A>(automaton: &A, state: A::State) -> f32
+where
+    A: Automaton + Send + Sync + 'static,
+    A::State: Clone,
+{
+    if TypeId::of::<DfaWrapper>() == automaton.type_id() && TypeId::of::<u32>() == state.type_id() {
+        let dfa = automaton as *const A as *const DfaWrapper;
+        let dfa = unsafe { &*dfa };
+
+        let id = &state as *const A::State as *const u32;
+        let id = unsafe { *id };
+
+        let dist = dfa.0.distance(id).to_u8() as f32;
+        1.0 / (1.0 + dist)
+    } else {
+        1.0
     }
 }
 

--- a/src/query/automaton_weight.rs
+++ b/src/query/automaton_weight.rs
@@ -56,7 +56,6 @@ where
         term_dict: &'a TermDictionary,
     ) -> io::Result<TermWithStateStreamer<'a, &'a A>> {
         let automaton: &A = &self.automaton;
-        // let mut term_stream_builder = term_dict.search(automaton);
         let mut term_stream_builder = term_dict.search_with_state(automaton);
 
         if let Some(json_path_bytes) = &self.json_path_bytes {

--- a/src/query/fuzzy_query.rs
+++ b/src/query/fuzzy_query.rs
@@ -294,7 +294,7 @@ mod test {
             let top_docs = searcher.search(&fuzzy_query, &TopDocs::with_limit(2))?;
             assert_eq!(top_docs.len(), 1, "Expected only 1 document");
             let (score, _) = top_docs[0];
-            assert_nearly_equals!(1.0, score);
+            assert_nearly_equals!(0.5, score);
         }
 
         // fails because non-prefix Levenshtein distance is more than 1 (add 'a' and 'n')

--- a/src/termdict/fst_termdict/mod.rs
+++ b/src/termdict/fst_termdict/mod.rs
@@ -24,5 +24,7 @@ mod term_info_store;
 mod termdict;
 
 pub use self::merger::TermMerger;
-pub use self::streamer::{TermStreamer, TermStreamerBuilder};
+pub use self::streamer::{
+    TermStreamer, TermStreamerBuilder, TermWithStateStreamer, TermWithStateStreamerBuilder,
+};
 pub use self::termdict::{TermDictionary, TermDictionaryBuilder};

--- a/src/termdict/fst_termdict/streamer.rs
+++ b/src/termdict/fst_termdict/streamer.rs
@@ -1,24 +1,25 @@
 use std::io;
 
-use tantivy_fst::automaton::AlwaysMatch;
-use tantivy_fst::map::{Stream, StreamBuilder};
-use tantivy_fst::{Automaton, IntoStreamer, Streamer};
-
 use super::TermDictionary;
 use crate::postings::TermInfo;
 use crate::termdict::TermOrdinal;
+use tantivy_fst::automaton::AlwaysMatch;
+use tantivy_fst::map::{Stream, StreamBuilder, StreamWithState};
+use tantivy_fst::{Automaton, IntoStreamer, Streamer};
 
 /// `TermStreamerBuilder` is a helper object used to define
 /// a range of terms that should be streamed.
 pub struct TermStreamerBuilder<'a, A = AlwaysMatch>
-where A: Automaton
+where
+    A: Automaton,
 {
     fst_map: &'a TermDictionary,
     stream_builder: StreamBuilder<'a, A>,
 }
 
 impl<'a, A> TermStreamerBuilder<'a, A>
-where A: Automaton
+where
+    A: Automaton,
 {
     pub(crate) fn new(fst_map: &'a TermDictionary, stream_builder: StreamBuilder<'a, A>) -> Self {
         TermStreamerBuilder {
@@ -73,7 +74,8 @@ where A: Automaton
 /// `TermStreamer` acts as a cursor over a range of terms of a segment.
 /// Terms are guaranteed to be sorted.
 pub struct TermStreamer<'a, A = AlwaysMatch>
-where A: Automaton
+where
+    A: Automaton,
 {
     pub(crate) fst_map: &'a TermDictionary,
     pub(crate) stream: Stream<'a, A>,
@@ -83,7 +85,8 @@ where A: Automaton
 }
 
 impl<'a, A> TermStreamer<'a, A>
-where A: Automaton
+where
+    A: Automaton,
 {
     /// Advance position the stream on the next item.
     /// Before the first call to `.advance()`, the stream
@@ -140,6 +143,156 @@ where A: Automaton
     pub fn next(&mut self) -> Option<(&[u8], &TermInfo)> {
         if self.advance() {
             Some((self.key(), self.value()))
+        } else {
+            None
+        }
+    }
+}
+
+/// `TermWithStateStreamerBuilder` is a helper object used to define
+/// a range of terms that should be streamed.
+pub struct TermWithStateStreamerBuilder<'a, A = AlwaysMatch>
+where
+    A: Automaton,
+    A::State: Clone,
+{
+    fst_map: &'a TermDictionary,
+    stream_builder: StreamBuilder<'a, A>,
+}
+
+impl<'a, A> TermWithStateStreamerBuilder<'a, A>
+where
+    A: Automaton,
+    A::State: Clone,
+{
+    pub(crate) fn new(fst_map: &'a TermDictionary, stream_builder: StreamBuilder<'a, A>) -> Self {
+        TermWithStateStreamerBuilder {
+            fst_map,
+            stream_builder,
+        }
+    }
+
+    /// Limit the range to terms greater or equal to the bound
+    pub fn ge<T: AsRef<[u8]>>(mut self, bound: T) -> Self {
+        self.stream_builder = self.stream_builder.ge(bound);
+        self
+    }
+
+    /// Limit the range to terms strictly greater than the bound
+    pub fn gt<T: AsRef<[u8]>>(mut self, bound: T) -> Self {
+        self.stream_builder = self.stream_builder.gt(bound);
+        self
+    }
+
+    /// Limit the range to terms lesser or equal to the bound
+    pub fn le<T: AsRef<[u8]>>(mut self, bound: T) -> Self {
+        self.stream_builder = self.stream_builder.le(bound);
+        self
+    }
+
+    /// Limit the range to terms lesser or equal to the bound
+    pub fn lt<T: AsRef<[u8]>>(mut self, bound: T) -> Self {
+        self.stream_builder = self.stream_builder.lt(bound);
+        self
+    }
+
+    /// Iterate over the range backwards.
+    pub fn backward(mut self) -> Self {
+        self.stream_builder = self.stream_builder.backward();
+        self
+    }
+
+    /// Creates the stream corresponding to the range
+    /// of terms defined using the `TermWithStateStreamerBuilder`.
+    pub fn into_stream(self) -> io::Result<TermWithStateStreamer<'a, A>> {
+        Ok(TermWithStateStreamer {
+            fst_map: self.fst_map,
+            stream: self.stream_builder.with_state().into_stream(),
+            term_ord: 0u64,
+            current_key: Vec::with_capacity(100),
+            current_value: TermInfo::default(),
+            current_state: None,
+        })
+    }
+}
+
+/// `TermWithStateStreamer` acts as a cursor over a range of terms of a segment.
+/// Terms are guaranteed to be sorted.
+pub struct TermWithStateStreamer<'a, A = AlwaysMatch>
+where
+    A: Automaton,
+    A::State: Clone,
+{
+    fst_map: &'a TermDictionary,
+    stream: StreamWithState<'a, A>,
+    term_ord: TermOrdinal,
+    current_key: Vec<u8>,
+    current_value: TermInfo,
+    current_state: Option<A::State>,
+}
+
+impl<'a, A> TermWithStateStreamer<'a, A>
+where
+    A: Automaton,
+    A::State: Clone,
+{
+    /// Advance position the stream on the next item.
+    /// Before the first call to `.advance()`, the stream
+    /// is an unitialized state.
+    pub fn advance(&mut self) -> bool {
+        if let Some((term, term_ord, state)) = self.stream.next() {
+            self.current_key.clear();
+            self.current_key.extend_from_slice(term);
+            self.term_ord = term_ord;
+            self.current_value = self.fst_map.term_info_from_ord(term_ord);
+            self.current_state = Some(state);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns the `TermOrdinal` of the given term.
+    ///
+    /// May panic if the called as `.advance()` as never
+    /// been called before.
+    pub fn term_ord(&self) -> TermOrdinal {
+        self.term_ord
+    }
+
+    /// Accesses the current key.
+    ///
+    /// `.key()` should return the key that was returned
+    /// by the `.next()` method.
+    ///
+    /// If the end of the stream as been reached, and `.next()`
+    /// has been called and returned `None`, `.key()` remains
+    /// the value of the last key encountered.
+    ///
+    /// Before any call to `.next()`, `.key()` returns an empty array.
+    pub fn key(&self) -> &[u8] {
+        &self.current_key
+    }
+
+    /// Accesses the current value.
+    ///
+    /// Calling `.value()` after the end of the stream will return the
+    /// last `.value()` encountered.
+    ///
+    /// # Panics
+    ///
+    /// Calling `.value()` before the first call to `.advance()` returns
+    /// `V::default()`.
+    pub fn value(&self) -> &TermInfo {
+        &self.current_value
+    }
+
+    /// Return the next `(key, value, state)` triplet.
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::should_implement_trait))]
+    pub fn next(&mut self) -> Option<(&[u8], &TermInfo, A::State)> {
+        if self.advance() {
+            let state = self.current_state.take().unwrap(); // always Some(_) after advance
+            Some((self.key(), self.value(), state))
         } else {
             None
         }

--- a/src/termdict/fst_termdict/termdict.rs
+++ b/src/termdict/fst_termdict/termdict.rs
@@ -6,7 +6,7 @@ use tantivy_fst::raw::Fst;
 use tantivy_fst::Automaton;
 
 use super::term_info_store::{TermInfoStore, TermInfoStoreWriter};
-use super::{TermStreamer, TermStreamerBuilder};
+use super::{TermStreamer, TermStreamerBuilder, TermWithStateStreamerBuilder};
 use crate::directory::{FileSlice, OwnedBytes};
 use crate::postings::TermInfo;
 use crate::termdict::TermOrdinal;
@@ -27,7 +27,8 @@ pub struct TermDictionaryBuilder<W> {
 }
 
 impl<W> TermDictionaryBuilder<W>
-where W: Write
+where
+    W: Write,
 {
     /// Creates a new `TermDictionaryBuilder`
     pub fn create(w: W) -> io::Result<Self> {
@@ -216,5 +217,16 @@ impl TermDictionary {
     pub fn search<'a, A: Automaton + 'a>(&'a self, automaton: A) -> TermStreamerBuilder<'a, A> {
         let stream_builder = self.fst_index.search(automaton);
         TermStreamerBuilder::<A>::new(self, stream_builder)
+    }
+
+    /// Returns a search builder, to stream all of the terms
+    /// within the Automaton
+    pub fn search_with_state<'a, A>(&'a self, automaton: A) -> TermWithStateStreamerBuilder<'a, A>
+    where
+        A: Automaton + 'a,
+        A::State: Clone,
+    {
+        let stream_builder = self.fst_index.search(automaton);
+        TermWithStateStreamerBuilder::<A>::new(self, stream_builder)
     }
 }

--- a/src/termdict/mod.rs
+++ b/src/termdict/mod.rs
@@ -41,11 +41,14 @@ use common::file_slice::FileSlice;
 use common::BinarySerializable;
 use tantivy_fst::Automaton;
 
-use self::termdict::{
-    TermDictionary as InnerTermDict, TermDictionaryBuilder as InnerTermDictBuilder,
-    TermStreamerBuilder,
+pub use self::termdict::{TermMerger, TermStreamer, TermWithStateStreamer};
+use self::{
+    fst_termdict::TermWithStateStreamerBuilder,
+    termdict::{
+        TermDictionary as InnerTermDict, TermDictionaryBuilder as InnerTermDictBuilder,
+        TermStreamerBuilder,
+    },
 };
-pub use self::termdict::{TermMerger, TermStreamer};
 use crate::postings::TermInfo;
 
 #[repr(u32)]
@@ -140,7 +143,9 @@ impl TermDictionary {
     /// Returns a search builder, to stream all of the terms
     /// within the Automaton
     pub fn search<'a, A: Automaton + 'a>(&'a self, automaton: A) -> TermStreamerBuilder<'a, A>
-    where A::State: Clone {
+    where
+        A::State: Clone,
+    {
         self.0.search(automaton)
     }
 
@@ -165,6 +170,16 @@ impl TermDictionary {
         limit: Option<u64>,
     ) -> FileSlice {
         self.0.file_slice_for_range(key_range, limit)
+    }
+
+    /// Returns a search builder, to stream all of the terms
+    /// within the Automaton
+    pub fn search_with_state<'a, A>(&'a self, automaton: A) -> TermWithStateStreamerBuilder<'a, A>
+    where
+        A: Automaton + 'a,
+        A::State: Clone,
+    {
+        self.0.search_with_state(automaton)
     }
 }
 

--- a/tests/fuzzy_scoring.rs
+++ b/tests/fuzzy_scoring.rs
@@ -1,0 +1,137 @@
+#[cfg(test)]
+mod test {
+    use maplit::hashmap;
+    use paradedb_tantivy::collector::TopDocs;
+    use paradedb_tantivy::doc;
+    use paradedb_tantivy::query::FuzzyTermQuery;
+    use paradedb_tantivy::schema::Schema;
+    use paradedb_tantivy::schema::{STORED, TEXT};
+    use paradedb_tantivy::Index;
+    use paradedb_tantivy::Term;
+
+    #[test]
+    pub fn test_fuzzy_term() {
+        // Define a list of documents to be indexed.  Each entry represents a text
+        // that will be associated with the field "country" in the index.
+        let docs = vec![
+            "WENN ROT WIE RUBIN",
+            "WENN ROT WIE ROBIN",
+            "WHEN RED LIKE ROBIN",
+            "WENN RED AS ROBIN",
+            "WHEN ROYAL BLUE ROBIN",
+            "IF RED LIKE RUBEN",
+            "WHEN GREEN LIKE ROBIN",
+            "WENN ROSE LIKE ROBIN",
+            "IF PINK LIKE ROBIN",
+            "WENN ROT WIE RABIN",
+            "WENN BLU WIE ROBIN",
+            "WHEN YELLOW LIKE RABBIT",
+            "IF BLUE LIKE ROBIN",
+            "WHEN ORANGE LIKE RIBBON",
+            "WENN VIOLET WIE RUBIX",
+            "WHEN INDIGO LIKE ROBBIE",
+            "IF TEAL LIKE RUBY",
+            "WHEN GOLD LIKE ROB",
+            "WENN SILVER WIE ROBY",
+            "IF BRONZE LIKE ROBE",
+        ];
+
+        // Define the expected scores when queried with "robin" and a fuzziness of 2.
+        // This map associates each document text with its expected score.
+        let expected_scores = hashmap! {
+            "WHEN GREEN LIKE ROBIN" => 1.0,
+            "WENN RED AS ROBIN" => 1.0,
+            "WHEN RED LIKE ROBIN" => 1.0,
+            "WENN ROSE LIKE ROBIN" => 1.0,
+            "WENN ROT WIE ROBIN" => 1.0,
+            "WHEN ROYAL BLUE ROBIN" => 1.0,
+            "IF PINK LIKE ROBIN" => 1.0,
+            "IF BLUE LIKE ROBIN" => 1.0,
+            "WENN BLU WIE ROBIN" => 1.0,
+            "WENN ROT WIE RUBIN" => 0.5,
+            "WENN ROT WIE RABIN" => 0.5,
+            "IF RED LIKE RUBEN" => 0.33333334,
+            "WENN VIOLET WIE RUBIX" => 0.33333334,
+            "IF BRONZE LIKE ROBE" => 0.33333334,
+            "WENN SILVER WIE ROBY" => 0.33333334,
+            "WHEN GOLD LIKE ROB" => 0.33333334,
+            "WHEN INDIGO LIKE ROBBIE" => 0.33333334,
+        };
+
+        // Build a schema for the index.
+        // The schema determines how documents are indexed and searched.
+        let mut schema_builder = Schema::builder();
+
+        // Add a text field named "country" to the schema. This field will store the text and
+        // is indexed in a way that makes it searchable.
+        let country_field = schema_builder.add_text_field("country", TEXT | STORED);
+        // Build the schema based on the provided definitions.
+        let schema = schema_builder.build();
+        // Create a new index in RAM based on the defined schema.
+        let index = Index::create_in_ram(schema);
+        {
+            // Create an index writer with one thread and a certain memory limit.
+            // The writer allows us to add documents to the index.
+            let mut index_writer = index.writer_with_num_threads(1, 10_000_000).unwrap();
+
+            // Index each document in the docs list.
+            for &doc in &docs {
+                index_writer
+                    .add_document(doc!(country_field => doc))
+                    .unwrap();
+            }
+
+            // Commit changes to the index. This finalizes the addition of documents.
+            index_writer.commit().unwrap();
+        }
+
+        // Create a reader for the index to search the indexed documents.
+        let reader = index.reader().unwrap();
+        let searcher = reader.searcher();
+
+        {
+            // Define a term based on the field "country" and the text "robin".
+            let term = Term::from_field_text(country_field, "robin");
+
+            // Create a fuzzy query for "robin", a fuzziness of 2, and a prefix length of 0.
+            let fuzzy_query = FuzzyTermQuery::new(term, 2, true);
+
+            // Search the index with the fuzzy query and retrieve up to 100 top documents.
+            let top_docs = searcher
+                .search(&fuzzy_query, &TopDocs::with_limit(100))
+                .unwrap();
+
+            // Print out the scores and documents retrieved by the search.
+            for (score, adr) in &top_docs {
+                let doc = searcher.doc(*adr).expect("document");
+                println!("{score}, {:?}", doc.field_values().first().unwrap().value);
+            }
+
+            // Assert that 17 documents match the fuzzy query criteria.
+            // We don't expect anything that has a larger fuzziness than 2
+            // to be returned in the query, leaving us with 17 expected results.
+            assert_eq!(top_docs.len(), 17, "Expected 17 documents");
+
+            // Check the scores of the returned documents against the expected scores.
+            for (score, adr) in &top_docs {
+                let doc = searcher.doc(*adr).expect("document");
+                let doc_text = doc
+                    .field_values()
+                    .first()
+                    .unwrap()
+                    .value()
+                    .as_text()
+                    .unwrap();
+
+                // Ensure the retrieved score for each document is close to the expected score.
+                assert!(
+                    (score - expected_scores[doc_text]).abs() < f32::EPSILON,
+                    "Unexpected score for document {}. Expected: {}, Actual: {}",
+                    doc_text,
+                    expected_scores[doc_text],
+                    score
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implementation mostly follows this PR from tantivy:
https://github.com/quickwit-oss/tantivy/pull/998

Added a test in `tests/fuzzy_scoring.rs`. You can run with `cargo test --test fuzzy_scoring`. `cargo test` won't work, because we've changed the name of the crate to `paradedb-tantivy`... so the other tests can't find their `tantivy` imports.

The maximum Levenshtein distance supported by Tantivy is 2, further work will be required to change this. Results outside of the distance won't be returned in the fuzzy search at all.