### PR TITLE
fix: point fst fork to paradedb to fix regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ regex = { version = "1.5.5", default-features = false, features = [
     "unicode",
 ] }
 aho-corasick = "1.0"
-tantivy-fst = "0.5"
+tantivy-fst = { git = "https://github.com/paradedb/fst.git", rev = "b42066f" }
 memmap2 = { version = "0.9.0", optional = true }
 lz4_flex = { version = "0.11", default-features = false, optional = true }
 zstd = { version = "0.13", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ regex = { version = "1.5.5", default-features = false, features = [
     "unicode",
 ] }
 aho-corasick = "1.0"
-tantivy-fst = { git = "https://github.com/paradedb/fst.git", rev = "b42066f" }
+tantivy-fst = { git = "https://github.com/paradedb/fst.git", rev = "11e8933" }
 memmap2 = { version = "0.9.0", optional = true }
 lz4_flex = { version = "0.11", default-features = false, optional = true }
 zstd = { version = "0.13", optional = true, default-features = false }

--- a/tests/fuzzy_scoring.rs
+++ b/tests/fuzzy_scoring.rs
@@ -3,8 +3,8 @@ mod test {
     use maplit::hashmap;
     use tantivy::collector::TopDocs;
     use tantivy::query::FuzzyTermQuery;
-    use tantivy::schema::{Schema, STORED, TEXT};
-    use tantivy::{doc, Index, Term};
+    use tantivy::schema::{Schema, Value, STORED, TEXT};
+    use tantivy::{doc, Index, TantivyDocument, Term};
 
     #[test]
     pub fn test_fuzzy_term() {
@@ -100,8 +100,11 @@ mod test {
 
             // Print out the scores and documents retrieved by the search.
             for (score, adr) in &top_docs {
-                let doc = searcher.doc(*adr).expect("document");
-                println!("{score}, {:?}", doc.field_values().first().unwrap().value);
+                let doc: TantivyDocument = searcher.doc(*adr).expect("document");
+                println!(
+                    "{score}, {:?}",
+                    doc.field_values().next().unwrap().1.as_str().unwrap()
+                );
             }
 
             // Assert that 17 documents match the fuzzy query criteria.
@@ -111,14 +114,8 @@ mod test {
 
             // Check the scores of the returned documents against the expected scores.
             for (score, adr) in &top_docs {
-                let doc = searcher.doc(*adr).expect("document");
-                let doc_text = doc
-                    .field_values()
-                    .first()
-                    .unwrap()
-                    .value()
-                    .as_text()
-                    .unwrap();
+                let doc: TantivyDocument = searcher.doc(*adr).expect("document");
+                let doc_text = doc.field_values().next().unwrap().1.as_str().unwrap();
 
                 // Ensure the retrieved score for each document is close to the expected score.
                 assert!(


### PR DESCRIPTION
Work in our fst fork has enabled ^ and $ to be used in regex queries.

I've also updated the test suite to make use of Tantivy's new `TantivyDocument` type, so they now correctly compile.