### PR TITLE
Add a `payload: &mut (dyn Any + '_)` argument to `Directory::save_meta()`

### DIFF
--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -1,15 +1,15 @@
+use crate::directory::directory_lock::Lock;
+use crate::directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError};
+use crate::directory::{FileHandle, FileSlice, WatchCallback, WatchHandle, WritePtr};
+use crate::index::SegmentMetaInventory;
+use crate::IndexMeta;
+use std::any::Any;
 use std::collections::HashSet;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use std::{fmt, io, thread};
-
-use crate::directory::directory_lock::Lock;
-use crate::directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError};
-use crate::directory::{FileHandle, FileSlice, WatchCallback, WatchHandle, WritePtr};
-use crate::index::SegmentMetaInventory;
-use crate::IndexMeta;
 
 /// Retry the logic of acquiring locks is pretty simple.
 /// We just retry `n` times after a given `duratio`, both
@@ -250,7 +250,12 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     }
 
     /// Allows the directory to save IndexMeta, overriding the SegmentUpdater's default save_meta
-    fn save_metas(&self, _metas: &IndexMeta, _previous_metas: &IndexMeta) -> crate::Result<()> {
+    fn save_metas(
+        &self,
+        _metas: &IndexMeta,
+        _previous_metas: &IndexMeta,
+        _payload: &mut (dyn Any + '_),
+    ) -> crate::Result<()> {
         Err(crate::TantivyError::InternalError(
             "save_meta not implemented".to_string(),
         ))

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -1,10 +1,10 @@
+use crc32fast::Hasher;
+use std::any::Any;
 use std::collections::HashSet;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{io, result};
-
-use crc32fast::Hasher;
 
 use crate::core::MANAGED_FILEPATH;
 use crate::directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError};
@@ -337,8 +337,13 @@ impl Directory for ManagedDirectory {
         Ok(())
     }
 
-    fn save_metas(&self, metas: &IndexMeta, previous_metas: &IndexMeta) -> crate::Result<()> {
-        self.directory.save_metas(metas, previous_metas)
+    fn save_metas(
+        &self,
+        metas: &IndexMeta,
+        previous_metas: &IndexMeta,
+        payload: &mut (dyn Any + '_),
+    ) -> crate::Result<()> {
+        self.directory.save_metas(metas, previous_metas, payload)
     }
 
     fn load_metas(&self, inventory: &SegmentMetaInventory) -> crate::Result<IndexMeta> {

--- a/src/index/segment_component.rs
+++ b/src/index/segment_component.rs
@@ -1,10 +1,11 @@
+use std::fmt::{Display, Formatter};
 use std::slice;
 
 /// Enum describing each component of a tantivy segment.
 /// Each component is stored in its own file,
 /// using the pattern `segment_uuid`.`component_extension`,
 /// except the delete component that takes an `segment_uuid`.`delete_opstamp`.`component_extension`
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
 pub enum SegmentComponent {
     /// Postings (or inverted list). Sorted lists of document ids, associated with terms
     Postings,
@@ -27,6 +28,39 @@ pub enum SegmentComponent {
     /// Bitset describing which document of the segment is alive.
     /// (It was representing deleted docs but changed to represent alive docs from v0.17)
     Delete,
+}
+
+impl TryFrom<&str> for SegmentComponent {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "idx" => Ok(SegmentComponent::Postings),
+            "pos" => Ok(SegmentComponent::Positions),
+            "term" => Ok(SegmentComponent::Terms),
+            "store" => Ok(SegmentComponent::Store),
+            "temp" => Ok(SegmentComponent::TempStore),
+            "fast" => Ok(SegmentComponent::FastFields),
+            "fieldnorm" => Ok(SegmentComponent::FieldNorms),
+            "del" => Ok(SegmentComponent::Delete),
+            other => Err(other.to_string()),
+        }
+    }
+}
+
+impl Display for SegmentComponent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SegmentComponent::Postings => write!(f, "idx"),
+            SegmentComponent::Positions => write!(f, "pos"),
+            SegmentComponent::FastFields => write!(f, "fast"),
+            SegmentComponent::FieldNorms => write!(f, "fieldnorm"),
+            SegmentComponent::Terms => write!(f, "term"),
+            SegmentComponent::Store => write!(f, "store"),
+            SegmentComponent::TempStore => write!(f, "temp"),
+            SegmentComponent::Delete => write!(f, "del"),
+        }
+    }
 }
 
 impl SegmentComponent {

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -43,7 +43,7 @@ pub(crate) fn save_metas(
 ) -> crate::Result<()> {
     info!("save metas");
 
-    match directory.save_metas(metas, previous_metas) {
+    match directory.save_metas(metas, previous_metas, &mut ()) {
         Ok(_) => Ok(()),
         Err(crate::TantivyError::InternalError(_)) => {
             let mut buffer = serde_json::to_vec_pretty(metas)?;


### PR DESCRIPTION

We add a "payload" argument to Directory's save_meta() function so that impl-specific data can be passed around, mutability, for use during the function.

We also add some helper around `SegmentComponent` to help convert to/from filenames and such.