### PR TITLE
perf: remove some fast fields loading overhead

### DIFF
--- a/src/index/index_meta.rs
+++ b/src/index/index_meta.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
@@ -309,7 +309,7 @@ pub struct IndexMeta {
     /// List of `SegmentMeta` information associated with each finalized segment of the index.
     pub segments: Vec<SegmentMeta>,
     /// Index `Schema`
-    pub schema: (Vec<u8>, OnceLock<Schema>),
+    pub schema: Schema,
     /// Opstamp associated with the last `commit` operation.
     pub opstamp: Opstamp,
     /// Payload associated with the last commit.

--- a/src/index/index_meta.rs
+++ b/src/index/index_meta.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use serde::{Deserialize, Serialize};
 
@@ -309,7 +309,7 @@ pub struct IndexMeta {
     /// List of `SegmentMeta` information associated with each finalized segment of the index.
     pub segments: Vec<SegmentMeta>,
     /// Index `Schema`
-    pub schema: Schema,
+    pub schema: (Vec<u8>, OnceLock<Schema>),
     /// Opstamp associated with the last `commit` operation.
     pub opstamp: Opstamp,
     /// Payload associated with the last commit.

--- a/src/index/segment_reader.rs
+++ b/src/index/segment_reader.rs
@@ -8,7 +8,7 @@ use fnv::FnvHashMap;
 use itertools::Itertools;
 
 use crate::directory::error::OpenReadError;
-use crate::directory::{CompositeFile, FileSlice, ManagedDirectory};
+use crate::directory::{CompositeFile, FileSlice};
 use crate::error::DataCorruption;
 use crate::fastfield::{intersect_alive_bitsets, AliveBitSet, FacetReader, FastFieldReaders};
 use crate::fieldnorm::{FieldNormReader, FieldNormReaders};
@@ -18,7 +18,7 @@ use crate::schema::{Field, IndexRecordOption, Schema, Type};
 use crate::space_usage::SegmentSpaceUsage;
 use crate::store::StoreReader;
 use crate::termdict::TermDictionary;
-use crate::{Directory, DocId, Index, Opstamp, SegmentMeta};
+use crate::{Directory, DocId, Index, Opstamp};
 
 /// Entry point to access all of the datastructures of the `Segment`
 ///


### PR DESCRIPTION
This removes up some overhead the profiler exposed.  In the case I was testing, fast fields no longer shows up in the profile at all.

I also renamed `BlockWithLength` to `BlockWithData`