### PR TITLE
perf: make the footer fixed width

### DIFF
--- a/src/compat_tests.rs
+++ b/src/compat_tests.rs
@@ -36,6 +36,7 @@ fn path_for_version(version: &str) -> String {
 /// feature flag quickwit uses a different dictionary type
 #[test]
 #[cfg(not(feature = "quickwit"))]
+#[ignore = "test incompatible with fixed-width footer changes"]
 fn test_format_6() {
     let path = path_for_version("6");
 
@@ -47,6 +48,7 @@ fn test_format_6() {
 /// feature flag quickwit uses a different dictionary type
 #[test]
 #[cfg(not(feature = "quickwit"))]
+#[ignore = "test incompatible with fixed-width footer changes"]
 fn test_format_7() {
     let path = path_for_version("7");
 

--- a/src/index/index_meta.rs
+++ b/src/index/index_meta.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
@@ -309,7 +309,7 @@ pub struct IndexMeta {
     /// List of `SegmentMeta` information associated with each finalized segment of the index.
     pub segments: Vec<SegmentMeta>,
     /// Index `Schema`
-    pub schema: (Vec<u8>, OnceLock<Schema>),
+    pub schema: Schema,
     /// Opstamp associated with the last `commit` operation.
     pub opstamp: Opstamp,
     /// Payload associated with the last commit.

--- a/src/index/index_meta.rs
+++ b/src/index/index_meta.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use serde::{Deserialize, Serialize};
 
@@ -309,7 +309,7 @@ pub struct IndexMeta {
     /// List of `SegmentMeta` information associated with each finalized segment of the index.
     pub segments: Vec<SegmentMeta>,
     /// Index `Schema`
-    pub schema: Schema,
+    pub schema: (Vec<u8>, OnceLock<Schema>),
     /// Opstamp associated with the last `commit` operation.
     pub opstamp: Opstamp,
     /// Payload associated with the last commit.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,10 +234,10 @@ pub const INDEX_FORMAT_OLDEST_SUPPORTED_VERSION: u32 = 4;
 /// Structure version for the index.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Version {
-    major: u32,
-    minor: u32,
-    patch: u32,
-    index_format_version: u32,
+    pub(crate) major: u32,
+    pub(crate) minor: u32,
+    pub(crate) patch: u32,
+    pub(crate) index_format_version: u32,
 }
 
 impl fmt::Debug for Version {


### PR DESCRIPTION
Prior to this commit, the Footer tantivy serialized at the end of every file included a json blob that could be an arbitrary size.

This changes the Footer to be exactly 24 bytes (6 u32s), making sure to keep the `crc` value.  The other change we make here is to not actually read/validate the footer bytes when opening a file.

From pg_search's perspective, this is quite unnecessary Postgres buffer cache I/O and increases index/segment opening overhead, which is something pg_search does often for each query.

Two tests are ignored here as they test physical index files stored here in the repo that this change completely breaks.