### PR TITLE
feat: Add ability to construct a `SegmentId` from raw bytes

### DIFF
--- a/src/index/segment_id.rs
+++ b/src/index/segment_id.rs
@@ -21,6 +21,14 @@ use uuid::Uuid;
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SegmentId(Uuid);
 
+impl Default for SegmentId {
+    fn default() -> Self {
+        Self(Uuid::from_bytes(uuid::Bytes::from([
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ])))
+    }
+}
+
 #[cfg(test)]
 static AUTO_INC_COUNTER: Lazy<atomic::AtomicUsize> = Lazy::new(atomic::AtomicUsize::default);
 
@@ -83,6 +91,10 @@ impl SegmentId {
     /// E.g. "a5c4dfcbdfe645089129e308e26d5523"
     pub fn from_uuid_string(uuid_string: &str) -> Result<SegmentId, SegmentIdParseError> {
         FromStr::from_str(uuid_string)
+    }
+
+    pub fn from_bytes(uuid_bytes: [u8; 16]) -> SegmentId {
+        SegmentId(Uuid::from_bytes(uuid::Bytes::from(uuid_bytes)))
     }
 }
 


### PR DESCRIPTION
This allows a `SegmentId` to be constructed from a `[u8; 16]` byte array.  It also adds a `impl Default for SegementId`, which defaults to all nulls