### PR TITLE
feat: make garbage collection opt-out

### DIFF
--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -278,6 +278,12 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     ) -> Option<Box<dyn MergePolicy>> {
         None
     }
+
+    /// Returns true if this directory supports garbage collection.  The default assumption is
+    /// `true`
+    fn supports_garbage_collection(&self) -> bool {
+        true
+    }
 }
 
 /// DirectoryClone

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -117,6 +117,13 @@ impl ManagedDirectory {
         &mut self,
         get_living_files: L,
     ) -> crate::Result<GarbageCollectionResult> {
+        if !self.supports_garbage_collection() {
+            // the underlying directory does not support garbage collection.
+            return Ok(GarbageCollectionResult {
+                deleted_files: vec![],
+                failed_to_delete_files: vec![],
+            });
+        }
         let mut files_to_delete = vec![];
 
         // We're about to do an atomic write to managed.json, lock it down
@@ -358,6 +365,10 @@ impl Directory for ManagedDirectory {
     ) -> Option<Box<dyn MergePolicy>> {
         self.directory
             .reconsider_merge_policy(metas, previous_metas)
+    }
+
+    fn supports_garbage_collection(&self) -> bool {
+        self.directory.supports_garbage_collection()
     }
 }
 


### PR DESCRIPTION
`Directory` now now has a function named `supports_garbage_collection` whose default implementation returns true.  And `ManagedDirectory` passes through to that.

If a concrete Directory impl returns false, then tantivy will not do garbage collection.

Among other things, this avoids, from the pg_search side of things, all calls to `Directory::list_managed_files()` and also provides some peace of mind that tantivy won't, somehow, try to delete segments out from underneath us.