### PR TITLE
feat: ability to assign a panic handler to a Directory

### DIFF
--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -102,6 +102,8 @@ fn retry_policy(is_blocking: bool) -> RetryPolicy {
     }
 }
 
+pub type DirectoryPanicHandler = Arc<dyn Fn(Box<dyn Any + Send>) + Send + Sync + 'static>;
+
 /// Write-once read many (WORM) abstraction for where
 /// tantivy's data should be stored.
 ///
@@ -283,6 +285,14 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     /// `true`
     fn supports_garbage_collection(&self) -> bool {
         true
+    }
+
+    /// Return a panic handler to be assigned to the various thread pools that may be created
+    ///
+    /// The default is [`None`], which indicates that an unhandled panic from a thread pool will
+    /// abort the process
+    fn panic_handler(&self) -> Option<DirectoryPanicHandler> {
+        None
     }
 }
 

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -11,8 +11,8 @@ use crate::core::MANAGED_FILEPATH;
 use crate::directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError};
 use crate::directory::footer::{Footer, FooterProxy, FOOTER_LEN};
 use crate::directory::{
-    DirectoryLock, FileHandle, FileSlice, GarbageCollectionResult, Lock, WatchCallback,
-    WatchHandle, WritePtr, MANAGED_LOCK, META_LOCK,
+    DirectoryLock, DirectoryPanicHandler, FileHandle, FileSlice, GarbageCollectionResult, Lock,
+    WatchCallback, WatchHandle, WritePtr, MANAGED_LOCK, META_LOCK,
 };
 use crate::error::DataCorruption;
 use crate::index::SegmentMetaInventory;
@@ -369,6 +369,10 @@ impl Directory for ManagedDirectory {
 
     fn supports_garbage_collection(&self) -> bool {
         self.directory.supports_garbage_collection()
+    }
+
+    fn panic_handler(&self) -> Option<DirectoryPanicHandler> {
+        self.directory.panic_handler()
     }
 }
 

--- a/src/directory/mod.rs
+++ b/src/directory/mod.rs
@@ -23,7 +23,7 @@ pub use common::file_slice::{FileHandle, FileSlice};
 pub use common::{AntiCallToken, OwnedBytes, TerminatingWrite};
 
 pub(crate) use self::composite_file::{CompositeFile, CompositeWrite};
-pub use self::directory::{Directory, DirectoryClone, DirectoryLock};
+pub use self::directory::{Directory, DirectoryClone, DirectoryLock, DirectoryPanicHandler};
 pub use self::directory_lock::{Lock, INDEX_WRITER_LOCK, MANAGED_LOCK, META_LOCK};
 pub use self::ram_directory::RamDirectory;
 pub use self::watch_event_router::{WatchCallback, WatchCallbackList, WatchHandle};

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -22,7 +22,7 @@ use crate::indexer::{MergePolicy, SegmentEntry, SegmentWriter};
 use crate::query::{EnableScoring, Query, TermQuery};
 use crate::schema::document::Document;
 use crate::schema::{IndexRecordOption, TantivyDocument, Term};
-use crate::{DocId, FutureResult, Opstamp};
+use crate::{Directory, DocId, FutureResult, Opstamp};
 
 // Size of the margin for the `memory_arena`. A segment is closed when the remaining memory
 // in the `memory_arena` goes below MARGIN_IN_BYTES.
@@ -331,6 +331,7 @@ impl<D: Document> IndexWriter<D> {
             stamper.clone(),
             &delete_queue.cursor(),
             options.num_merge_threads,
+            index.directory().panic_handler(),
         )?;
 
         let mut index_writer = Self {


### PR DESCRIPTION
Tantivy creates thread pools for some of its background work, specifically committing and merging.

It's possible if one of the thread workers panics that rayon will simply abort the process.  This is terrible from pg_search as that takes down the entire Postgres cluster.

These changes allow a Directory to assign a panic handler that gets called in such cases.  Which allows pg_search to gracefully rollback the current transaction, while presenting the panic message to the user.