### PR TITLE
feat: Add `Directory::wants_cancel()` function

### DIFF
--- a/columnar/src/columnar/merge/mod.rs
+++ b/columnar/src/columnar/merge/mod.rs
@@ -4,6 +4,7 @@ mod term_merger;
 
 use std::collections::{BTreeMap, HashSet};
 use std::io;
+use std::io::ErrorKind;
 use std::net::Ipv6Addr;
 use std::sync::Arc;
 
@@ -78,6 +79,7 @@ pub fn merge_columnar(
     required_columns: &[(String, ColumnType)],
     merge_row_order: MergeRowOrder,
     output: &mut impl io::Write,
+    cancel: impl Fn() -> bool,
 ) -> io::Result<()> {
     let mut serializer = ColumnarSerializer::new(output);
     let num_rows_per_columnar = columnar_readers
@@ -88,6 +90,9 @@ pub fn merge_columnar(
     let columns_to_merge =
         group_columns_for_merge(columnar_readers, required_columns, &merge_row_order)?;
     for res in columns_to_merge {
+        if cancel() {
+            return Err(io::Error::new(ErrorKind::Interrupted, "Merge cancelled"));
+        }
         let ((column_name, _column_type_category), grouped_columns) = res;
         let grouped_columns = grouped_columns.open(&merge_row_order)?;
         if grouped_columns.is_empty() {

--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -294,6 +294,13 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     fn panic_handler(&self) -> Option<DirectoryPanicHandler> {
         None
     }
+
+    /// Returns true if this directory is in a position of requiring that tantivy cancel
+    /// whatever operation(s) it might be doing  Typically this is just for the background
+    /// merge processes but could be used for anything
+    fn wants_cancel(&self) -> bool {
+        false
+    }
 }
 
 /// DirectoryClone

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -374,6 +374,10 @@ impl Directory for ManagedDirectory {
     fn panic_handler(&self) -> Option<DirectoryPanicHandler> {
         self.directory.panic_handler()
     }
+
+    fn wants_cancel(&self) -> bool {
+        self.directory.wants_cancel()
+    }
 }
 
 impl Clone for ManagedDirectory {

--- a/src/error.rs
+++ b/src/error.rs
@@ -110,6 +110,9 @@ pub enum TantivyError {
     #[error("Deserialize error: {0}")]
     /// An error occurred while attempting to deserialize a document.
     DeserializeError(DeserializeError),
+    /// The user requested the current operation be cancelled
+    #[error("User requested cancel")]
+    Cancelled,
 }
 
 impl From<io::Error> for TantivyError {

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -332,6 +332,10 @@ impl<D: Document> IndexWriter<D> {
             &delete_queue.cursor(),
             options.num_merge_threads,
             index.directory().panic_handler(),
+            {
+                let index = index.clone();
+                move || index.directory().wants_cancel()
+            },
         )?;
 
         let mut index_writer = Self {


### PR DESCRIPTION
This adds a function named `wants_cancel() -> bool` to the `Directory` trait.  It allows a Directory implementation to indicate that it would like Tantivy to cancel an operation.

Right now, querying this function only happens during key points of index merging, but _could_ be used in other places.  Technically, segment merging is the only "black box" in tantivy that users don't otherwise have the direct ability to control.

The default implementaiton of `wants_cancel()` returns false, so there's no fear of default tantivy spuriously cancelling a merge.

The cancels happen "cleanly" such that if `wants_cancel()` returns true an `Err(TantivyError::Cancelled)` is returned from the calling function at that point, and the error result will be propogated up the stack.  No panics are raised.