### PR TITLE
feat: remove `Directory::reconsider_merge_policy()` and add other niceties to Directory API

### DIFF
--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -12,7 +12,6 @@ use crate::directory::directory_lock::Lock;
 use crate::directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError};
 use crate::directory::{FileHandle, FileSlice, WatchCallback, WatchHandle, WritePtr};
 use crate::index::SegmentMetaInventory;
-use crate::merge_policy::MergePolicy;
 use crate::IndexMeta;
 
 /// Retry the logic of acquiring locks is pretty simple.

--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{fmt, io, thread};
 
+use log::Level;
+
 use crate::directory::directory_lock::Lock;
 use crate::directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError};
 use crate::directory::{FileHandle, FileSlice, WatchCallback, WatchHandle, WritePtr};
@@ -300,6 +302,11 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     /// merge processes but could be used for anything
     fn wants_cancel(&self) -> bool {
         false
+    }
+
+    /// Send a logging message to the Directory to handle in its own way
+    fn log(&self, message: &str) {
+        log!(Level::Info, "{message}");
     }
 }
 

--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -272,17 +272,6 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
         ))
     }
 
-    // Allows the directory to change the writer's merge policy right before the merge happens
-    // This is useful for directories that need to change the merge policy based on how many
-    // segments were created
-    fn reconsider_merge_policy(
-        &self,
-        _metas: &IndexMeta,
-        _previous_metas: &IndexMeta,
-    ) -> Option<Box<dyn MergePolicy>> {
-        None
-    }
-
     /// Returns true if this directory supports garbage collection.  The default assumption is
     /// `true`
     fn supports_garbage_collection(&self) -> bool {

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -378,6 +378,10 @@ impl Directory for ManagedDirectory {
     fn wants_cancel(&self) -> bool {
         self.directory.wants_cancel()
     }
+
+    fn log(&self, message: &str) {
+        self.directory.log(message);
+    }
 }
 
 impl Clone for ManagedDirectory {

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -16,7 +16,6 @@ use crate::directory::{
 };
 use crate::error::DataCorruption;
 use crate::index::SegmentMetaInventory;
-use crate::merge_policy::MergePolicy;
 use crate::{Directory, IndexMeta};
 
 /// Returns true if the file is "managed".

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -358,15 +358,6 @@ impl Directory for ManagedDirectory {
         self.directory.load_metas(inventory)
     }
 
-    fn reconsider_merge_policy(
-        &self,
-        metas: &IndexMeta,
-        previous_metas: &IndexMeta,
-    ) -> Option<Box<dyn MergePolicy>> {
-        self.directory
-            .reconsider_merge_policy(metas, previous_metas)
-    }
-
     fn supports_garbage_collection(&self) -> bool {
         self.directory.supports_garbage_collection()
     }

--- a/src/index/index_meta.rs
+++ b/src/index/index_meta.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::fmt;
+use std::fmt::{Debug, Formatter};
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -21,6 +22,14 @@ pub struct DeleteMeta {
 #[derive(Clone, Default)]
 pub struct SegmentMetaInventory {
     inventory: Inventory<InnerSegmentMeta>,
+}
+
+impl Debug for SegmentMetaInventory {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SegmentMetaInventory")
+            .field("inventory", &self.inventory.list())
+            .finish()
+    }
 }
 
 impl SegmentMetaInventory {

--- a/src/indexer/segment_manager.rs
+++ b/src/indexer/segment_manager.rs
@@ -141,10 +141,6 @@ impl SegmentManager {
         registers_lock.committed.clear();
         registers_lock.uncommitted.clear();
         for segment_entry in segment_entries {
-            index.directory().log(
-                &serde_json::to_string(&("SegmentManager::commit", &segment_entry.meta()))
-                    .expect("Failed to serialize SegmentEntry"),
-            );
             registers_lock.committed.add_segment_entry(segment_entry);
         }
     }
@@ -167,10 +163,6 @@ impl SegmentManager {
                     "Segment id not found {}. Should never happen because of the contains all \
                      if-block.",
                 );
-                index.directory().log(&serde_json::to_string(&(
-                    "start_merge:uncommitted",
-                    segment_entry.meta(),
-                ))?);
                 segment_entries.push(segment_entry);
             }
         } else if registers_lock.committed.contains_all(segment_ids) {
@@ -179,11 +171,6 @@ impl SegmentManager {
                     "Segment id not found {}. Should never happen because of the contains all \
                      if-block.",
                 );
-
-                index.directory().log(&serde_json::to_string(&(
-                    "start_merge:committed",
-                    segment_entry.meta(),
-                ))?);
 
                 segment_entries.push(segment_entry);
             }

--- a/src/indexer/segment_manager.rs
+++ b/src/indexer/segment_manager.rs
@@ -7,7 +7,7 @@ use crate::error::TantivyError;
 use crate::index::{SegmentId, SegmentMeta};
 use crate::indexer::delete_queue::DeleteCursor;
 use crate::indexer::SegmentEntry;
-use crate::{Directory, Index};
+use crate::Index;
 
 #[derive(Default)]
 struct SegmentRegisters {
@@ -136,7 +136,7 @@ impl SegmentManager {
         registers_lock.uncommitted.clear();
     }
 
-    pub fn commit(&self, index: &Index, segment_entries: Vec<SegmentEntry>) {
+    pub fn commit(&self, _index: &Index, segment_entries: Vec<SegmentEntry>) {
         let mut registers_lock = self.write();
         registers_lock.committed.clear();
         registers_lock.uncommitted.clear();
@@ -152,7 +152,7 @@ impl SegmentManager {
     /// uncommitted.
     pub fn start_merge(
         &self,
-        index: &Index,
+        _index: &Index,
         segment_ids: &[SegmentId],
     ) -> crate::Result<Vec<SegmentEntry>> {
         let registers_lock = self.read();

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -521,7 +521,7 @@ impl SegmentUpdater {
         let segment_updater = self.clone();
         self.schedule_task(move || {
             let segment_entries = segment_updater.purge_deletes(opstamp)?;
-            let previous_metas = segment_updater.index.load_metas()?;
+            let previous_metas = segment_updater.load_meta();
             segment_updater
                 .segment_manager
                 .commit(&segment_updater.index, segment_entries);


### PR DESCRIPTION
This removes `Directory::reconsider_merge_policy()`.  After reconsidering this, it's better to make this decision ahead of time.

Also adds a `Directory::log(message: &str)` function along with passing a `Directory` reference to `MergePolicy::compute_merge_candidates()`.

It also hits some `#[derive(Debug)]` and `#[derive(Serialize)]` on a couple of structs that can benefit.