### PR TITLE
feat: ability to directly merge segments in the foregound

### DIFF
--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -297,6 +297,14 @@ impl Directory for ManagedDirectory {
 
     fn open_read(&self, path: &Path) -> result::Result<FileSlice, OpenReadError> {
         let file_slice = self.directory.open_read(path)?;
+        debug_assert!(
+            {
+                use common::HasLen;
+                file_slice.len() >= FOOTER_LEN
+            },
+            "{} is too short",
+            path.display()
+        );
         let (reader, _) = file_slice.split_from_end(FOOTER_LEN);
         // NB:  We do not read/validate the footer here -- we blindly skip it entirely
         Ok(reader)
@@ -385,7 +393,6 @@ impl Clone for ManagedDirectory {
 #[cfg(feature = "mmap")]
 #[cfg(test)]
 mod tests_mmap_specific {
-
     use std::collections::HashSet;
     use std::io::Write;
     use std::path::{Path, PathBuf};

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -564,6 +564,20 @@ impl<D: Document> IndexWriter<D> {
         segment_updater.start_merge(merge_operation)
     }
 
+    /// Merges a given list of segments.  This is a blocking operation that performs
+    /// the merge in the calling thread (foreground).
+    ///
+    /// If all segments are empty no new segment will be created.
+    ///
+    /// `segment_ids` is required to be non-empty.
+    pub fn merge_foreground(
+        &mut self,
+        segment_ids: &[SegmentId],
+    ) -> crate::Result<Option<SegmentMeta>> {
+        let merge_operation = self.segment_updater.make_merge_operation(segment_ids);
+        self.segment_updater.merge_foreground(merge_operation)
+    }
+
     /// Closes the current document channel send.
     /// and replace all the channels by new ones.
     ///


### PR DESCRIPTION
This adds new public-facing (and internal) APIs for being able to merge a list of segments in the foreground, without using any threads.

For pg_search, this is beneficial because it allows us to merge directly using our `MVCCDirectory` rather than going through the `ChannelDirectory`, which has quite a bit of overhead.