### PR TITLE
fix: don't use `StoreWriter` if no fields are stored

### DIFF
--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -578,7 +578,9 @@ impl IndexMerger {
         )?;
 
         debug!("write-storagefields");
-        self.write_storable_fields(serializer.get_store_writer())?;
+        if self.schema.fields().any(|(_, f)| f.is_stored()) {
+            self.write_storable_fields(serializer.get_store_writer())?;
+        }
         debug!("write-fastfields");
         self.write_fast_fields(serializer.get_fast_field_write(), doc_id_mapping)?;
 

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -353,8 +353,10 @@ impl SegmentWriter {
         self.doc_opstamps.push(opstamp);
         self.fast_field_writers.add_document(&document)?;
         self.index_document(&document)?;
-        let doc_writer = self.segment_serializer.get_store_writer();
-        doc_writer.store(&document, &self.schema)?;
+        if self.schema.fields().any(|(_, f)| f.is_stored()) {
+            let doc_writer = self.segment_serializer.get_store_writer();
+            doc_writer.store(&document, &self.schema)?;
+        }
         self.max_doc += 1;
         Ok(())
     }


### PR DESCRIPTION
Don't serialize/store documents if none of the fields are stored, this reduces write amplification