### PR TITLE
chore: allow `merge_foreground` to ignore the store

### DIFF
--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -559,7 +559,7 @@ impl<D: Document> IndexWriter<D> {
     ///
     /// `segment_ids` is required to be non-empty.
     pub fn merge(&mut self, segment_ids: &[SegmentId]) -> FutureResult<Option<SegmentMeta>> {
-        let merge_operation = self.segment_updater.make_merge_operation(segment_ids);
+        let merge_operation = self.segment_updater.make_merge_operation(segment_ids, false);
         let segment_updater = self.segment_updater.clone();
         segment_updater.start_merge(merge_operation)
     }
@@ -573,8 +573,9 @@ impl<D: Document> IndexWriter<D> {
     pub fn merge_foreground(
         &mut self,
         segment_ids: &[SegmentId],
+        ignore_store: bool,
     ) -> crate::Result<Option<SegmentMeta>> {
-        let merge_operation = self.segment_updater.make_merge_operation(segment_ids);
+        let merge_operation = self.segment_updater.make_merge_operation(segment_ids, ignore_store);
         self.segment_updater.merge_foreground(merge_operation)
     }
 

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -559,7 +559,9 @@ impl<D: Document> IndexWriter<D> {
     ///
     /// `segment_ids` is required to be non-empty.
     pub fn merge(&mut self, segment_ids: &[SegmentId]) -> FutureResult<Option<SegmentMeta>> {
-        let merge_operation = self.segment_updater.make_merge_operation(segment_ids, false);
+        let merge_operation = self
+            .segment_updater
+            .make_merge_operation(segment_ids, false);
         let segment_updater = self.segment_updater.clone();
         segment_updater.start_merge(merge_operation)
     }
@@ -575,7 +577,9 @@ impl<D: Document> IndexWriter<D> {
         segment_ids: &[SegmentId],
         ignore_store: bool,
     ) -> crate::Result<Option<SegmentMeta>> {
-        let merge_operation = self.segment_updater.make_merge_operation(segment_ids, ignore_store);
+        let merge_operation = self
+            .segment_updater
+            .make_merge_operation(segment_ids, ignore_store);
         self.segment_updater.merge_foreground(merge_operation)
     }
 

--- a/src/indexer/merge_operation.rs
+++ b/src/indexer/merge_operation.rs
@@ -47,6 +47,7 @@ pub struct MergeOperation {
 pub(crate) struct InnerMergeOperation {
     target_opstamp: Opstamp,
     segment_ids: Vec<SegmentId>,
+    ignore_store: bool,
 }
 
 impl MergeOperation {
@@ -54,10 +55,12 @@ impl MergeOperation {
         inventory: &MergeOperationInventory,
         target_opstamp: Opstamp,
         segment_ids: Vec<SegmentId>,
+        ignore_store: bool,
     ) -> MergeOperation {
         let inner_merge_operation = InnerMergeOperation {
             target_opstamp,
             segment_ids,
+            ignore_store,
         };
         MergeOperation {
             inner: inventory.track(inner_merge_operation),
@@ -73,5 +76,10 @@ impl MergeOperation {
     /// Returns the list of segment to be merged.
     pub fn segment_ids(&self) -> &[SegmentId] {
         &self.inner.segment_ids[..]
+    }
+
+    /// Returns true if the store should be ignored during merge.
+    pub fn ignore_store(&self) -> bool {
+        self.inner.ignore_store
     }
 }

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -544,9 +544,18 @@ impl SegmentUpdater {
         self.active_index_meta.read().unwrap().clone()
     }
 
-    pub(crate) fn make_merge_operation(&self, segment_ids: &[SegmentId], ignore_store: bool) -> MergeOperation {
+    pub(crate) fn make_merge_operation(
+        &self,
+        segment_ids: &[SegmentId],
+        ignore_store: bool,
+    ) -> MergeOperation {
         let commit_opstamp = self.load_meta().opstamp;
-        MergeOperation::new(&self.merge_operations, commit_opstamp, segment_ids.to_vec(), ignore_store)
+        MergeOperation::new(
+            &self.merge_operations,
+            commit_opstamp,
+            segment_ids.to_vec(),
+            ignore_store,
+        )
     }
 
     // Starts a merge operation. This function will block until the merge operation is effectively
@@ -691,7 +700,12 @@ impl SegmentUpdater {
             .compute_merge_candidates(Some(self.index.directory()), &uncommitted_segments)
             .into_iter()
             .map(|merge_candidate| {
-                MergeOperation::new(&self.merge_operations, current_opstamp, merge_candidate.0, false)
+                MergeOperation::new(
+                    &self.merge_operations,
+                    current_opstamp,
+                    merge_candidate.0,
+                    false,
+                )
             })
             .collect();
 
@@ -700,7 +714,12 @@ impl SegmentUpdater {
             .compute_merge_candidates(Some(self.index.directory()), &committed_segments)
             .into_iter()
             .map(|merge_candidate: MergeCandidate| {
-                MergeOperation::new(&self.merge_operations, commit_opstamp, merge_candidate.0, false)
+                MergeOperation::new(
+                    &self.merge_operations,
+                    commit_opstamp,
+                    merge_candidate.0,
+                    false,
+                )
             });
         merge_candidates.extend(committed_merge_candidates);
 

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -128,6 +128,7 @@ fn merge(
     mut segment_entries: Vec<SegmentEntry>,
     target_opstamp: Opstamp,
     cancel: Box<dyn CancelSentinel>,
+    ignore_store: bool,
 ) -> crate::Result<Option<SegmentEntry>> {
     let num_docs = segment_entries
         .iter()
@@ -154,7 +155,7 @@ fn merge(
         .collect();
 
     // An IndexMerger is like a "view" of our merged segments.
-    let merger = IndexMerger::open(index.schema(), &segments[..], cancel)?;
+    let merger = IndexMerger::open(index.schema(), &segments[..], cancel, ignore_store)?;
 
     // ... we just serialize this index merger in our new segment to merge the segments.
     let segment_serializer = SegmentSerializer::for_segment(merged_segment.clone())?;
@@ -271,6 +272,7 @@ pub fn merge_filtered_segments<T: Into<Box<dyn Directory>>>(
         segments,
         filter_doc_ids,
         cancel,
+        false,
     )?;
     let segment_serializer = SegmentSerializer::for_segment(merged_segment)?;
     let num_docs = merger.write(segment_serializer)?;
@@ -542,9 +544,9 @@ impl SegmentUpdater {
         self.active_index_meta.read().unwrap().clone()
     }
 
-    pub(crate) fn make_merge_operation(&self, segment_ids: &[SegmentId]) -> MergeOperation {
+    pub(crate) fn make_merge_operation(&self, segment_ids: &[SegmentId], ignore_store: bool) -> MergeOperation {
         let commit_opstamp = self.load_meta().opstamp;
-        MergeOperation::new(&self.merge_operations, commit_opstamp, segment_ids.to_vec())
+        MergeOperation::new(&self.merge_operations, commit_opstamp, segment_ids.to_vec(), ignore_store)
     }
 
     // Starts a merge operation. This function will block until the merge operation is effectively
@@ -605,6 +607,7 @@ impl SegmentUpdater {
                 segment_entries,
                 merge_operation.target_opstamp(),
                 cancel,
+                false,
             ) {
                 Ok(after_merge_segment_entry) => {
                     let res = segment_updater.end_merge(merge_operation, after_merge_segment_entry);
@@ -651,6 +654,7 @@ impl SegmentUpdater {
             segment_entries,
             merge_operation.target_opstamp(),
             cancel,
+            merge_operation.ignore_store(),
         ) {
             Ok(after_merge_segment_entry) => {
                 segment_updater.end_merge_foreground(merge_operation, after_merge_segment_entry)
@@ -687,7 +691,7 @@ impl SegmentUpdater {
             .compute_merge_candidates(Some(self.index.directory()), &uncommitted_segments)
             .into_iter()
             .map(|merge_candidate| {
-                MergeOperation::new(&self.merge_operations, current_opstamp, merge_candidate.0)
+                MergeOperation::new(&self.merge_operations, current_opstamp, merge_candidate.0, false)
             })
             .collect();
 
@@ -696,7 +700,7 @@ impl SegmentUpdater {
             .compute_merge_candidates(Some(self.index.directory()), &committed_segments)
             .into_iter()
             .map(|merge_candidate: MergeCandidate| {
-                MergeOperation::new(&self.merge_operations, commit_opstamp, merge_candidate.0)
+                MergeOperation::new(&self.merge_operations, commit_opstamp, merge_candidate.0, false)
             });
         merge_candidates.extend(committed_merge_candidates);
 
@@ -1279,6 +1283,7 @@ mod tests {
                 &segments[..],
                 filter_segments,
                 Box::new(|| false),
+                false,
             )?;
 
             let doc_ids_alive: Vec<_> = merger.readers[0].doc_ids_alive().collect();
@@ -1295,6 +1300,7 @@ mod tests {
                 &segments[..],
                 filter_segments,
                 Box::new(|| false),
+                false,
             )?;
 
             let doc_ids_alive: Vec<_> = merger.readers[0].doc_ids_alive().collect();

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -49,7 +49,9 @@ pub use self::explanation::Explanation;
 pub(crate) use self::fuzzy_query::DfaWrapper;
 pub use self::fuzzy_query::FuzzyTermQuery;
 pub use self::intersection::{intersect_scorers, Intersection};
-pub use self::more_like_this::{MoreLikeThis, MoreLikeThisQuery, MoreLikeThisQueryBuilder, ScoreTerm};
+pub use self::more_like_this::{
+    MoreLikeThis, MoreLikeThisQuery, MoreLikeThisQueryBuilder, ScoreTerm,
+};
 pub use self::phrase_prefix_query::PhrasePrefixQuery;
 pub use self::phrase_query::regex_phrase_query::{wildcard_query_to_regex_str, RegexPhraseQuery};
 pub use self::phrase_query::PhraseQuery;


### PR DESCRIPTION
Required for https://github.com/paradedb/paradedb/pull/2484

In pg_search, we've made it so that Tantivy doesn't write to the store at all. This works except for Tantivy's merge process, which unconditionally tries to read the store file. These changes make it so we can tell merge not to do that.