### PR TITLE
Expose some methods which are necessary to create a streaming version of `sorted_ords_to_term_cb`.

### DIFF
--- a/sstable/src/dictionary.rs
+++ b/sstable/src/dictionary.rs
@@ -148,7 +148,7 @@ impl<TSSTable: SSTable> Dictionary<TSSTable> {
         }
     }
 
-    pub(crate) fn sstable_delta_reader_block(
+    pub fn sstable_delta_reader_block(
         &self,
         block_addr: BlockAddr,
     ) -> io::Result<DeltaReader<TSSTable::ValueReader>> {

--- a/sstable/src/sstable_index_v3.rs
+++ b/sstable/src/sstable_index_v3.rs
@@ -58,7 +58,7 @@ impl SSTableIndex {
     }
 
     /// Get the [`BlockAddr`] of the block containing the `ord`-th term.
-    pub(crate) fn get_block_with_ord(&self, ord: TermOrdinal) -> BlockAddr {
+    pub fn get_block_with_ord(&self, ord: TermOrdinal) -> BlockAddr {
         match self {
             SSTableIndex::V2(v2_index) => v2_index.get_block_with_ord(ord),
             SSTableIndex::V3(v3_index) => v3_index.get_block_with_ord(ord),


### PR DESCRIPTION
See https://github.com/paradedb/paradedb/pull/2612.

We might eventually want that function upstreamed, but there are more changes planned to it for https://github.com/paradedb/paradedb/issues/2619, so doing the expedient thing now.