### PR TITLE
fix: custom serialization for `IntermediateTermBucketResult`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ lz4_flex = { version = "0.11", default-features = false, optional = true }
 zstd = { version = "0.13", optional = true, default-features = false }
 tempfile = { version = "3.12.0", optional = true }
 log = "0.4.16"
-serde = { version = "1.0.136", features = ["derive"] }
-serde_json = "1.0.79"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
 fs4 = { version = "0.8.0", optional = true }
 levenshtein_automata = "0.2.1"
 uuid = { version = "1.0.0", features = ["v4", "serde"] }


### PR DESCRIPTION
The `IntermediateTermBucketResult` type can't be serialized (to at least json) using the default serdie derive macros due to its inner `entries` map having a non-String key.

This implements custom serialization for this type, which unrolls the `entries` map into an array of `(key, value)` pairs.

Also updates tantivy's `serde` dependencies for good measure.