### PR TITLE
Fix `TopNComputer` threshold comparison

### DIFF
--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -1067,6 +1067,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use proptest::prelude::*;
+
     use super::{TopDocs, TopNComputer};
     use crate::collector::top_collector::ComparableDoc;
     use crate::collector::Collector;
@@ -1119,72 +1121,41 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_empty_topn_computer() {
-        let mut computer: TopNComputer<u32, u32> = TopNComputer::new(0);
-
-        computer.push(1u32, 1u32);
-        computer.push(1u32, 2u32);
-        computer.push(1u32, 3u32);
-        assert!(computer.into_sorted_vec().is_empty());
-    }
-    #[test]
-    fn test_topn_computer() {
-        let mut computer: TopNComputer<u32, u32> = TopNComputer::new(2);
-
-        computer.push(1u32, 1u32);
-        computer.push(2u32, 2u32);
-        computer.push(3u32, 3u32);
-        computer.push(2u32, 4u32);
-        computer.push(1u32, 5u32);
-        assert_eq!(
-            computer.into_sorted_vec(),
-            &[
-                ComparableDoc {
-                    feature: 3u32,
-                    doc: 3u32,
-                },
-                ComparableDoc {
-                    feature: 2u32,
-                    doc: 2u32,
-                }
-            ]
-        );
-    }
-    #[test]
-    fn test_topn_computer_asc() {
-        let mut computer: TopNComputer<u32, u32, false> = TopNComputer::new(2);
-
-        computer.push(1u32, 1u32);
-        computer.push(2u32, 2u32);
-        computer.push(3u32, 3u32);
-        computer.push(2u32, 4u32);
-        computer.push(4u32, 5u32);
-        computer.push(1u32, 6u32);
-        assert_eq!(
-            computer.into_sorted_vec(),
-            &[
-                ComparableDoc {
-                    feature: 1u32,
-                    doc: 1u32,
-                },
-                ComparableDoc {
-                    feature: 1u32,
-                    doc: 6u32,
-                }
-            ]
-        );
-    }
-
-    #[test]
-    fn test_topn_computer_no_panic() {
-        for top_n in 0..10 {
-            let mut computer: TopNComputer<u32, u32> = TopNComputer::new(top_n);
-
-            for _ in 0..1 + top_n * 2 {
-                computer.push(1u32, 1u32);
+    proptest! {
+        #[test]
+        fn test_topn_computer_asc(
+          limit in 0..10_usize,
+          docs in proptest::collection::vec((0..100_u64, 0..100_u64), 0..100_usize),
+        ) {
+            let mut computer: TopNComputer<_, _, false> = TopNComputer::new(limit);
+            for (feature, doc) in &docs {
+                computer.push(*feature, *doc);
             }
-            let _vals = computer.into_sorted_vec();
+            let mut comparable_docs = docs.into_iter().map(|(feature, doc)| ComparableDoc { feature, doc }).collect::<Vec<_>>();
+            comparable_docs.sort();
+            comparable_docs.truncate(limit);
+            prop_assert_eq!(
+                computer.into_sorted_vec(),
+                comparable_docs,
+            );
+        }
+
+        #[test]
+        fn test_topn_computer_desc(
+          limit in 0..10_usize,
+          docs in proptest::collection::vec((0..100_u64, 0..100_u64), 0..100_usize),
+        ) {
+            let mut computer: TopNComputer<_, _, true> = TopNComputer::new(limit);
+            for (feature, doc) in &docs {
+                computer.push(*feature, *doc);
+            }
+            let mut comparable_docs = docs.into_iter().map(|(feature, doc)| ComparableDoc { feature, doc }).collect::<Vec<_>>();
+            comparable_docs.sort();
+            comparable_docs.truncate(limit);
+            prop_assert_eq!(
+                computer.into_sorted_vec(),
+                comparable_docs,
+            );
         }
     }
 


### PR DESCRIPTION
The `TopNComputer` was refactored in 0e04ec3136b9553f7435fd2ac11d2dc325d4cede to support both ascending and descending order. But that refactor did not adjust the `TopNComputer::threshold` to include the `ComparableDoc`, which is what provides the relevant `Ord` implementation.

Add a simple failing test, make it pass, and then expand the tests into proptests (which are already in use elsewhere in the codebase).

Upstream at: https://github.com/quickwit-oss/tantivy/pull/2651