### PR TITLE
perf: lazily open positions file

### DIFF
--- a/src/index/segment_reader.rs
+++ b/src/index/segment_reader.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, OnceLock, RwLock};
 use std::{fmt, io};
 
+use common::file_slice::DeferredFileSlice;
 use fnv::FnvHashMap;
 use itertools::Itertools;
 
@@ -236,19 +237,38 @@ impl SegmentReader {
                 ))
             })?;
 
-        let positions_file = self.positions_composite().open_read(field).ok_or_else(|| {
-            let error_msg = format!(
-                "Failed to open field {:?}'s positions in the composite file. Has the schema been \
-                 modified?",
-                field_entry.name()
-            );
-            DataCorruption::comment_only(error_msg)
-        })?;
+        // not all queries require positions.
+        // we can defer opening the file until needed
+        let positions_file_opener = {
+            let path = self.relative_path(SegmentComponent::Positions);
+            let directory = self.index.directory().clone();
+            let field_entry = field_entry.clone();
+            move || {
+                let composite_file = if let Ok(positions_file) = &directory.open_read(&path) {
+                    CompositeFile::open(&positions_file)
+                        .expect("should be able to open positions composite component")
+                } else {
+                    CompositeFile::empty()
+                };
+
+                composite_file.open_read(field).ok_or_else(|| {
+                    let error_msg = format!(
+                        "Failed to open field {:?}'s positions in the composite file. Has the \
+                         schema been modified?",
+                        field_entry.name()
+                    );
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("{:?}", DataCorruption::comment_only(error_msg)),
+                    )
+                })
+            }
+        };
 
         let inv_idx_reader = Arc::new(InvertedIndexReader::new(
             TermDictionary::open(termdict_file)?,
             postings_file,
-            positions_file,
+            DeferredFileSlice::new(positions_file_opener),
             record_option,
         )?);
 

--- a/src/termdict/sstable_termdict/mod.rs
+++ b/src/termdict/sstable_termdict/mod.rs
@@ -158,10 +158,12 @@ impl ValueReader for TermInfoValueReader {
 
     fn load(&mut self, mut data: &[u8]) -> io::Result<usize> {
         let len_before = data.len();
-        self.term_infos.clear();
         let num_els = VInt::deserialize_u64(&mut data)?;
         let mut postings_start = VInt::deserialize_u64(&mut data)? as usize;
         let mut positions_start = VInt::deserialize_u64(&mut data)? as usize;
+
+        self.term_infos.clear();
+        self.term_infos.reserve_exact(num_els as usize);
         for _ in 0..num_els {
             let doc_freq = VInt::deserialize_u64(&mut data)? as u32;
             let postings_num_bytes = VInt::deserialize_u64(&mut data)?;


### PR DESCRIPTION
Not all queries use positions and it's okay if we (from the perspective of `pg_search`, anyways) defer opening/loading them until they're first needed.

This saves a lot of disk I/O when an index has lots of segments and the query doesn't need positions.

As a drive by, make sure a random Vec has enough space before pushing items to it.  This showed up in the profiler, believe it or not.