### PR TITLE
Avoid copying into `OwnedBytes` when opening a fast field column `Dictionary`.

### DIFF
--- a/columnar/src/column/serialize.rs
+++ b/columnar/src/column/serialize.rs
@@ -120,8 +120,7 @@ pub fn open_column_bytes(
     );
     let (dictionary_bytes, column_bytes) = body.split(dictionary_len as usize);
 
-    let dictionary_bytes = dictionary_bytes.read_bytes()?;
-    let dictionary = Arc::new(Dictionary::from_bytes(dictionary_bytes)?);
+    let dictionary = Arc::new(Dictionary::open(dictionary_bytes)?);
     let term_ord_column = crate::column::open_column_u64::<u64>(column_bytes, format_version)?;
     Ok(BytesColumn {
         dictionary,

--- a/sstable/src/dictionary.rs
+++ b/sstable/src/dictionary.rs
@@ -55,7 +55,7 @@ impl Dictionary<VoidSSTable> {
             dictionary_writer.insert(term, &()).unwrap();
         }
         dictionary_writer.finish().unwrap();
-        Dictionary::from_bytes(OwnedBytes::new(buffer)).unwrap()
+        Dictionary::from_bytes_for_tests(OwnedBytes::new(buffer)).unwrap()
     }
 }
 
@@ -322,7 +322,7 @@ impl<TSSTable: SSTable> Dictionary<TSSTable> {
     }
 
     /// Creates a term dictionary from the supplied bytes.
-    pub fn from_bytes(owned_bytes: OwnedBytes) -> io::Result<Self> {
+    pub fn from_bytes_for_tests(owned_bytes: OwnedBytes) -> io::Result<Self> {
         Dictionary::open(FileSlice::new(Arc::new(owned_bytes)))
     }
 

--- a/sstable/src/streamer.rs
+++ b/sstable/src/streamer.rs
@@ -307,7 +307,7 @@ mod tests {
         dict_builder.insert(b"abandon", &3)?;
         let buffer = dict_builder.finish()?;
         let owned_bytes = OwnedBytes::new(buffer);
-        Dictionary::from_bytes(owned_bytes)
+        Dictionary::from_bytes_for_tests(owned_bytes)
     }
 
     #[test]


### PR DESCRIPTION
When a fast fields string/bytes `Dictionary` is opened, we currently read the entire dictionary from `FileSlice` -> `OwnedBytes`... and then immediately wrap it back into a `FileSlice`.

Switching to `Dictionary::open` preserves the `FileSlice`, such that only the portions of the `Dictionary` which are actually accessed are read from disk/buffers.