### PR TITLE
fix: Properly handle nulls in TopOrderable

### DIFF
--- a/src/collector/top_orderable.rs
+++ b/src/collector/top_orderable.rs
@@ -1071,7 +1071,7 @@ pub trait TopNCompare {
     type Accepted: Clone + PartialOrd;
 
     /// Given the current threshold of accepted values and a candidate doc_id/score, compare the
-    /// candidate value to the threshold, and convert the candidate to Accepted if it is TODO-than
+    /// candidate value to the threshold, and convert the candidate to Accepted if it is greater-than
     /// the threshold.
     fn accept(
         &self,
@@ -1081,9 +1081,7 @@ pub trait TopNCompare {
         doc_id: DocId,
     ) -> Option<Self::Accepted>;
 
-    /// Given the current threshold of accepted values and a candidate doc_id/score, compare the
-    /// candidate value to the threshold, and convert the candidate to Accepted if it is TODO-than
-    /// the threshold.
+    /// Get an Accepted value for the given Score and DocId.
     fn get(&self, score: Score, doc_id: DocId) -> Self::Accepted;
 }
 

--- a/src/collector/top_orderable.rs
+++ b/src/collector/top_orderable.rs
@@ -1121,6 +1121,13 @@ mod tests {
                 altitude => 40.0,
             )],
         )?;
+        create_segment(
+            &index,
+            vec![doc!(
+                catchphrase => "No, No, No",
+                altitude => 0.0,
+            )],
+        )?;
         Ok(index)
     }
 
@@ -1277,9 +1284,9 @@ mod tests {
             &index,
             Order::Asc,
             vec![
+                (0.0, DocAddress::new(2, 0)),
                 (27.0, DocAddress::new(0, 1)),
                 (40.0, DocAddress::new(1, 0)),
-                (149.0, DocAddress::new(0, 0)),
             ],
         )?;
 
@@ -1312,18 +1319,18 @@ mod tests {
         assert_eq!(
             &query(&index, Order::Asc)?,
             &[
-                ((0.13353144,), DocAddress::new(0, 0)),
-                ((0.18360573,), DocAddress::new(0, 1)),
-                ((0.20983513,), DocAddress::new(1, 0)),
+                ((0.35667497,), DocAddress::new(0, 0)),
+                ((0.4904281,), DocAddress::new(0, 1)),
+                ((0.5604893,), DocAddress::new(1, 0)),
             ]
         );
 
         assert_eq!(
             &query(&index, Order::Desc)?,
             &[
-                ((0.20983513,), DocAddress::new(1, 0)),
-                ((0.18360573,), DocAddress::new(0, 1)),
-                ((0.13353144,), DocAddress::new(0, 0)),
+                ((0.5604893,), DocAddress::new(1, 0)),
+                ((0.4904281,), DocAddress::new(0, 1)),
+                ((0.35667497,), DocAddress::new(0, 0)),
             ]
         );
         Ok(())

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -453,9 +453,9 @@ impl TopDocs {
     /// assert_eq!(
     ///     top_docs,
     ///     &[
-    ///         ((1.0, "austin".to_owned()), DocAddress::new(0, 0)),
-    ///         ((1.0, "greenville".to_owned()), DocAddress::new(0, 1)),
-    ///         ((1.0, "tokyo".to_owned()), DocAddress::new(0, 2)),
+    ///         ((1.0, Some("austin".to_owned())), DocAddress::new(0, 0)),
+    ///         ((1.0, Some("greenville".to_owned())), DocAddress::new(0, 1)),
+    ///         ((1.0, Some("tokyo".to_owned())), DocAddress::new(0, 2)),
     ///     ]
     /// );
     /// # Ok(())


### PR DESCRIPTION
Adjusts `Feature` to use `Option` where necessary. `StringFeature::SegmentOutput` avoids being wrapped in an `Option` because the `u64::MAX` "niche" is safe to use in that case (since it would require that many terms to trigger a collision).

Surprisingly, no performance impact downstream.