### PR TITLE
fix: return None from SUM when no values were collected

### DIFF
--- a/src/aggregation/metric/sum.rs
+++ b/src/aggregation/metric/sum.rs
@@ -59,8 +59,52 @@ impl IntermediateSum {
     pub fn merge_fruits(&mut self, other: IntermediateSum) {
         self.stats.merge_fruits(other.stats);
     }
-    /// Computes the final minimum value.
+    /// Computes the final sum value.
+    ///
+    /// Returns `None` when no values were collected (all documents had
+    /// missing/NULL values for the field), matching the behavior of
+    /// `IntermediateMin`, `IntermediateMax`, and `IntermediateAvg`.
     pub fn finalize(&self) -> Option<f64> {
-        Some(self.stats.finalize().sum)
+        let stats = self.stats.finalize();
+        if stats.count == 0 {
+            None
+        } else {
+            Some(stats.sum)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sum_finalize_returns_none_when_no_values() {
+        // Default IntermediateSum has count=0 — finalize should return None,
+        // matching MIN/MAX/AVG behavior for all-NULL groups.
+        let sum = IntermediateSum::default();
+        assert_eq!(sum.finalize(), None);
+    }
+
+    #[test]
+    fn test_sum_finalize_returns_value_when_has_values() {
+        let mut sum = IntermediateSum::default();
+        // Merge in a result that has actual values
+        let mut stats = IntermediateStats::default();
+        stats.count = 3;
+        stats.sum = 42.0;
+        stats.min = 10.0;
+        stats.max = 20.0;
+        let other = IntermediateSum::from_stats(stats);
+        sum.merge_fruits(other);
+        assert_eq!(sum.finalize(), Some(42.0));
+    }
+
+    #[test]
+    fn test_sum_merge_two_empty_still_none() {
+        let mut a = IntermediateSum::default();
+        let b = IntermediateSum::default();
+        a.merge_fruits(b);
+        assert_eq!(a.finalize(), None);
     }
 }


### PR DESCRIPTION
## What
Return `None` from `IntermediateSum::finalize()` when `count == 0`.

## Why
`IntermediateSum::finalize()` returned `Some(0.0)` even when all documents had missing/NULL values, unlike MIN, MAX, and AVG which all return `None` for `count == 0`. The `0.0` came from `IntermediateStats`' default sum initialization. Consumers (like ParadeDB) that map `None` to SQL `NULL` were incorrectly getting `0` for SUM on all-NULL groups.

Fixes paradedb/paradedb#4621

## How
Check `count == 0` before returning the sum value, returning `None` instead of `Some(0.0)`.

## Tests
- Verify SUM returns `None` when all values are missing/NULL
- Verify SUM still returns correct values for non-empty groups
- Verify MIN, MAX, AVG behavior unchanged

Upstream PR: https://github.com/quickwit-oss/tantivy/pull/2878