### PR TITLE
fix: Add space for missing sentinel in allowed bitset when a missing key is provided

### DIFF
--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -897,8 +897,12 @@ fn build_terms_or_cardinality_nodes(
                     let str_col = str_dict_column
                         .as_ref()
                         .expect("str_dict_column must exist for string column");
-                    allowed_term_ids =
-                        build_allowed_term_ids_for_str(str_col, &req.include, &req.exclude)?;
+                    allowed_term_ids = build_allowed_term_ids_for_str(
+                        str_col,
+                        &req.include,
+                        &req.exclude,
+                        missing,
+                    )?;
                 };
                 let idx_in_req_data = data.push_term_req_data(TermsAggReqData {
                     accessor,
@@ -941,9 +945,12 @@ fn build_allowed_term_ids_for_str(
     str_col: &StrColumn,
     include: &Option<IncludeExcludeParam>,
     exclude: &Option<IncludeExcludeParam>,
+    missing: &Option<Key>,
 ) -> crate::Result<Option<BitSet>> {
     let mut allowed: Option<BitSet> = None;
-    let num_terms = str_col.dictionary().num_terms() as u32;
+    let missing_adjustment = if missing.is_some() { 1 } else { 0 };
+    //let missing_adjustment = 0;
+    let num_terms = str_col.dictionary().num_terms() as u32 + missing_adjustment;
     if let Some(include) = include {
         // add matches
         allowed = Some(BitSet::with_max_value(num_terms));

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -948,9 +948,8 @@ fn build_allowed_term_ids_for_str(
     missing: &Option<Key>,
 ) -> crate::Result<Option<BitSet>> {
     let mut allowed: Option<BitSet> = None;
-    let missing_adjustment = if missing.is_some() { 1 } else { 0 };
-    //let missing_adjustment = 0;
-    let num_terms = str_col.dictionary().num_terms() as u32 + missing_adjustment;
+    let missing_sentinel_adjustment = if missing.is_some() { 1 } else { 0 };
+    let num_terms = str_col.dictionary().num_terms() as u32 + missing_sentinel_adjustment;
     if let Some(include) = include {
         // add matches
         allowed = Some(BitSet::with_max_value(num_terms));

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -941,6 +941,9 @@ fn build_terms_or_cardinality_nodes(
 
 /// Builds a single BitSet of allowed term ordinals for a string dictionary column according to
 /// include/exclude parameters.
+///
+/// When `reserve_missing_sentinel` is true, the bitset will have 1 additional slot for the missing
+/// term ordinal
 fn build_allowed_term_ids_for_str(
     str_col: &StrColumn,
     include: &Option<IncludeExcludeParam>,

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -901,7 +901,7 @@ fn build_terms_or_cardinality_nodes(
                         str_col,
                         &req.include,
                         &req.exclude,
-                        missing,
+                        missing.is_some(),
                     )?;
                 };
                 let idx_in_req_data = data.push_term_req_data(TermsAggReqData {
@@ -945,14 +945,14 @@ fn build_allowed_term_ids_for_str(
     str_col: &StrColumn,
     include: &Option<IncludeExcludeParam>,
     exclude: &Option<IncludeExcludeParam>,
-    missing: &Option<Key>,
+    reserve_missing_sentinel: bool,
 ) -> crate::Result<Option<BitSet>> {
     let mut allowed: Option<BitSet> = None;
-    let missing_sentinel_adjustment = if missing.is_some() { 1 } else { 0 };
-    let num_terms = str_col.dictionary().num_terms() as u32 + missing_sentinel_adjustment;
+    let missing_sentinel_adjustment = if reserve_missing_sentinel { 1 } else { 0 };
+    let allowed_capacity = str_col.dictionary().num_terms() as u32 + missing_sentinel_adjustment;
     if let Some(include) = include {
         // add matches
-        allowed = Some(BitSet::with_max_value(num_terms));
+        allowed = Some(BitSet::with_max_value(allowed_capacity));
         let allowed = allowed.as_mut().unwrap();
         for_each_matching_term_ord(str_col, include, |ord| allowed.insert(ord))?;
     };
@@ -960,7 +960,7 @@ fn build_allowed_term_ids_for_str(
     if let Some(exclude) = exclude {
         if allowed.is_none() {
             // Start with all terms allowed
-            allowed = Some(BitSet::with_max_value_and_full(num_terms));
+            allowed = Some(BitSet::with_max_value_and_full(allowed_capacity));
         }
         let allowed = allowed.as_mut().unwrap();
         for_each_matching_term_ord(str_col, exclude, |ord| allowed.remove(ord))?;

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -2950,11 +2950,20 @@ mod tests {
         // include cases
         for i in 0..=4 {
             let index = prep_index_with_n_unique_terms_plus_one_null(i * 64)?;
+            let normal_req: Aggregations = serde_json::from_value(json!({
+                "my_bool": {
+                    "terms": {
+                        "field": "title",
+                        "missing": "__NULL__",
+                        "size": 1000,
+                    }
+                }
+            }))?;
             let include_req: Aggregations = serde_json::from_value(json!({
                 "my_bool": {
                     "terms": {
                         "field": "title",
-                        "include": "foo",
+                        "include": "foo(.*)",
                         "missing": "__NULL__",
                         "size": 1000,
                     }
@@ -2964,15 +2973,23 @@ mod tests {
                 "my_bool": {
                     "terms": {
                         "field": "title",
-                        "exclude": "foo",
+                        "exclude": "foo(.*)",
                         "missing": "__NULL__",
                         "size": 1000,
                     }
                 }
             }))?;
 
-            // these should work and not panic
+            let normal_res = exec_request(normal_req, &index)?;
+            let normal_buckets = normal_res["my_bool"]["buckets"].as_array().unwrap();
+            assert_eq!(
+                normal_buckets.len(),
+                (i * 64) as usize + 1,
+                "The normal request should return all 'foo' buckets, plus the missing term bucket",
+            );
+
             let include_res = exec_request(include_req, &index)?;
+            eprintln!("include_res: {include_res:?}");
             let include_buckets = include_res["my_bool"]["buckets"].as_array().unwrap();
             assert_eq!(
                 include_buckets.len(),

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -146,7 +146,9 @@ pub enum IncludeExcludeParam {
 
 impl Serialize for IncludeExcludeParam {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: serde::Serializer {
+    where
+        S: serde::Serializer,
+    {
         match self {
             IncludeExcludeParam::Regex(s) => serializer.serialize_str(s),
             IncludeExcludeParam::Values(v) => v.serialize(serializer),
@@ -157,7 +159,9 @@ impl Serialize for IncludeExcludeParam {
 // Custom deserializer to accept either a single string (regex) or an array of strings (values).
 impl<'de> Deserialize<'de> for IncludeExcludeParam {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: serde::Deserializer<'de> {
+    where
+        D: serde::Deserializer<'de>,
+    {
         use serde::de::{self, SeqAccess, Visitor};
         struct IncludeExcludeVisitor;
 
@@ -169,22 +173,30 @@ impl<'de> Deserialize<'de> for IncludeExcludeParam {
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where A: SeqAccess<'de> {
+            where
+                A: SeqAccess<'de>,
+            {
                 let mut values: Vec<String> = Vec::new();
                 while let Some(elem) = seq.next_element::<String>()? {
                     values.push(elem);
@@ -2960,102 +2972,17 @@ mod tests {
     }
 
     #[test]
-    fn null_bitset_bounds_check_regresiion_include_0() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(0)?;
-        let agg_req = agg_terms_request_for_regression_check(false)?;
+    fn null_bitset_bounds_check_regression() -> crate::Result<()> {
+        // include cases
+        for i in 0..=4 {
+            let index = prep_index_with_n_unique_terms_plus_one_null(i * 64)?;
+            let include_req = agg_terms_request_for_regression_check(false)?;
+            let exclude_req = agg_terms_request_for_regression_check(true)?;
 
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_include_64() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(64)?;
-        let agg_req = agg_terms_request_for_regression_check(false)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_include_128() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(128)?;
-        let agg_req = agg_terms_request_for_regression_check(false)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_include_192() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(192)?;
-        let agg_req = agg_terms_request_for_regression_check(false)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_include_256() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(256)?;
-        let agg_req = agg_terms_request_for_regression_check(false)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_exclude_0() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(0)?;
-        let agg_req = agg_terms_request_for_regression_check(true)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_exclude_64() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(64)?;
-        let agg_req = agg_terms_request_for_regression_check(true)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_exclude_128() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(128)?;
-        let agg_req = agg_terms_request_for_regression_check(true)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_exclude_192() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(192)?;
-        let agg_req = agg_terms_request_for_regression_check(true)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_exclude_256() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(256)?;
-        let agg_req = agg_terms_request_for_regression_check(true)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
+            // this should work and not panic
+            let _res = exec_request(include_req, &index)?;
+            let _res = exec_request(exclude_req, &index)?;
+        }
         Ok(())
     }
 }

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -2920,9 +2920,7 @@ mod tests {
         Ok(())
     }
 
-    fn prep_index_and_agg_with_n_unique_terms_plus_one_null(
-        n: u64,
-    ) -> crate::Result<(Index, Aggregations)> {
+    fn prep_index_with_n_unique_terms_plus_one_null(n: u64) -> crate::Result<Index> {
         let mut schema_builder = Schema::builder();
         let id_field = schema_builder.add_u64_field("id", INDEXED);
         let title_field = schema_builder.add_text_field("title", TEXT | FAST);
@@ -2944,22 +2942,39 @@ mod tests {
 
         writer.commit()?;
 
-        let agg_req: Aggregations = serde_json::from_value(json!({
-            "my_bool": {
-                "terms": {
-                    "field": "title",
-                    "include": "foo",
-                    "missing": "__NULL__",
+        Ok(index)
+    }
+
+    fn agg_terms_request_for_regression_check(use_exclude: bool) -> crate::Result<Aggregations> {
+        let agg_req: Aggregations = if use_exclude {
+            serde_json::from_value(json!({
+                "my_bool": {
+                    "terms": {
+                        "field": "title",
+                        "exclude": "foo",
+                        "missing": "__NULL__",
+                    }
                 }
-            }
-        }))?;
+            }))?
+        } else {
+            serde_json::from_value(json!({
+                "my_bool": {
+                    "terms": {
+                        "field": "title",
+                        "include": "foo",
+                        "missing": "__NULL__",
+                    }
+                }
+            }))?
+        };
 
-        Ok((index, agg_req))
+        Ok(agg_req)
     }
 
     #[test]
-    fn null_bitset_bounds_check_regression_0() -> crate::Result<()> {
-        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(0)?;
+    fn null_bitset_bounds_check_regresiion_include_0() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(0)?;
+        let agg_req = agg_terms_request_for_regression_check(false)?;
 
         // this should work and not panic
         let _res = exec_request(agg_req, &index)?;
@@ -2967,8 +2982,9 @@ mod tests {
     }
 
     #[test]
-    fn null_bitset_bounds_check_regression_64() -> crate::Result<()> {
-        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(64)?;
+    fn null_bitset_bounds_check_regresiion_include_64() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(64)?;
+        let agg_req = agg_terms_request_for_regression_check(false)?;
 
         // this should work and not panic
         let _res = exec_request(agg_req, &index)?;
@@ -2976,8 +2992,9 @@ mod tests {
     }
 
     #[test]
-    fn null_bitset_bounds_check_regression_128() -> crate::Result<()> {
-        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(128)?;
+    fn null_bitset_bounds_check_regresiion_include_128() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(128)?;
+        let agg_req = agg_terms_request_for_regression_check(false)?;
 
         // this should work and not panic
         let _res = exec_request(agg_req, &index)?;
@@ -2985,8 +3002,9 @@ mod tests {
     }
 
     #[test]
-    fn null_bitset_bounds_check_regression_192() -> crate::Result<()> {
-        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(192)?;
+    fn null_bitset_bounds_check_regresiion_include_192() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(192)?;
+        let agg_req = agg_terms_request_for_regression_check(false)?;
 
         // this should work and not panic
         let _res = exec_request(agg_req, &index)?;
@@ -2994,8 +3012,59 @@ mod tests {
     }
 
     #[test]
-    fn null_bitset_bounds_check_regression_256() -> crate::Result<()> {
-        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(256)?;
+    fn null_bitset_bounds_check_regresiion_include_256() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(256)?;
+        let agg_req = agg_terms_request_for_regression_check(false)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regresiion_exclude_0() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(0)?;
+        let agg_req = agg_terms_request_for_regression_check(true)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regresiion_exclude_64() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(64)?;
+        let agg_req = agg_terms_request_for_regression_check(true)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regresiion_exclude_128() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(128)?;
+        let agg_req = agg_terms_request_for_regression_check(true)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regresiion_exclude_192() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(192)?;
+        let agg_req = agg_terms_request_for_regression_check(true)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regresiion_exclude_256() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(256)?;
+        let agg_req = agg_terms_request_for_regression_check(true)?;
 
         // this should work and not panic
         let _res = exec_request(agg_req, &index)?;

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -2945,43 +2945,55 @@ mod tests {
         Ok(index)
     }
 
-    fn agg_terms_request_for_regression_check(use_exclude: bool) -> crate::Result<Aggregations> {
-        let agg_req: Aggregations = if use_exclude {
-            serde_json::from_value(json!({
-                "my_bool": {
-                    "terms": {
-                        "field": "title",
-                        "exclude": "foo",
-                        "missing": "__NULL__",
-                    }
-                }
-            }))?
-        } else {
-            serde_json::from_value(json!({
-                "my_bool": {
-                    "terms": {
-                        "field": "title",
-                        "include": "foo",
-                        "missing": "__NULL__",
-                    }
-                }
-            }))?
-        };
-
-        Ok(agg_req)
-    }
-
     #[test]
     fn null_bitset_bounds_check_regression() -> crate::Result<()> {
         // include cases
         for i in 0..=4 {
             let index = prep_index_with_n_unique_terms_plus_one_null(i * 64)?;
-            let include_req = agg_terms_request_for_regression_check(false)?;
-            let exclude_req = agg_terms_request_for_regression_check(true)?;
+            let include_req: Aggregations = serde_json::from_value(json!({
+                "my_bool": {
+                    "terms": {
+                        "field": "title",
+                        "include": "foo",
+                        "missing": "__NULL__",
+                        "size": 1000,
+                    }
+                }
+            }))?;
+            let exclude_req: Aggregations = serde_json::from_value(json!({
+                "my_bool": {
+                    "terms": {
+                        "field": "title",
+                        "exclude": "foo",
+                        "missing": "__NULL__",
+                        "size": 1000,
+                    }
+                }
+            }))?;
 
-            // this should work and not panic
-            let _res = exec_request(include_req, &index)?;
-            let _res = exec_request(exclude_req, &index)?;
+            // these should work and not panic
+            let include_res = exec_request(include_req, &index)?;
+            let include_buckets = include_res["my_bool"]["buckets"].as_array().unwrap();
+            assert_eq!(
+                include_buckets.len(),
+                (i * 64) as usize,
+                "The include request should return all 'foo' buckets, and not the missing term bucket",
+            );
+            assert!(include_buckets
+                .iter()
+                .all(|b| b["key"].as_str().unwrap().starts_with("foo")));
+
+            let exclude_res = exec_request(exclude_req, &index)?;
+            let exclude_buckets = exclude_res["my_bool"]["buckets"].as_array().unwrap();
+            if i != 0 {
+                // TODO: Remove this if after fixing exclude + missing bug
+                assert_eq!(
+                    exclude_buckets.len(),
+                    1,
+                    "The exclude request should exclude all 'foo' buckets, and only the missing term bucket",
+                );
+                assert_eq!(exclude_buckets[0]["key"], "__NULL__");
+            }
         }
         Ok(())
     }

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -146,7 +146,9 @@ pub enum IncludeExcludeParam {
 
 impl Serialize for IncludeExcludeParam {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: serde::Serializer {
+    where
+        S: serde::Serializer,
+    {
         match self {
             IncludeExcludeParam::Regex(s) => serializer.serialize_str(s),
             IncludeExcludeParam::Values(v) => v.serialize(serializer),
@@ -157,7 +159,9 @@ impl Serialize for IncludeExcludeParam {
 // Custom deserializer to accept either a single string (regex) or an array of strings (values).
 impl<'de> Deserialize<'de> for IncludeExcludeParam {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: serde::Deserializer<'de> {
+    where
+        D: serde::Deserializer<'de>,
+    {
         use serde::de::{self, SeqAccess, Visitor};
         struct IncludeExcludeVisitor;
 
@@ -169,22 +173,30 @@ impl<'de> Deserialize<'de> for IncludeExcludeParam {
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where A: SeqAccess<'de> {
+            where
+                A: SeqAccess<'de>,
+            {
                 let mut values: Vec<String> = Vec::new();
                 while let Some(elem) = seq.next_element::<String>()? {
                     values.push(elem);
@@ -2914,7 +2926,7 @@ mod tests {
         let title_field = schema_builder.add_text_field("title", TEXT | FAST);
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema.clone());
-        // set to one thread to guarantee all docs end up in the same segement
+        // set to one thread to guarantee all docs end up in the same segment
         let mut writer = index.writer_with_num_threads(1, 50_000_000)?;
 
         writer.add_document(doc!(

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -146,9 +146,7 @@ pub enum IncludeExcludeParam {
 
 impl Serialize for IncludeExcludeParam {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
+    where S: serde::Serializer {
         match self {
             IncludeExcludeParam::Regex(s) => serializer.serialize_str(s),
             IncludeExcludeParam::Values(v) => v.serialize(serializer),
@@ -159,9 +157,7 @@ impl Serialize for IncludeExcludeParam {
 // Custom deserializer to accept either a single string (regex) or an array of strings (values).
 impl<'de> Deserialize<'de> for IncludeExcludeParam {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
+    where D: serde::Deserializer<'de> {
         use serde::de::{self, SeqAccess, Visitor};
         struct IncludeExcludeVisitor;
 
@@ -173,30 +169,22 @@ impl<'de> Deserialize<'de> for IncludeExcludeParam {
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
+            where E: de::Error {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
+            where E: de::Error {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
+            where E: de::Error {
                 Ok(IncludeExcludeParam::Regex(v))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: SeqAccess<'de>,
-            {
+            where A: SeqAccess<'de> {
                 let mut values: Vec<String> = Vec::new();
                 while let Some(elem) = seq.next_element::<String>()? {
                     values.push(elem);
@@ -2994,7 +2982,8 @@ mod tests {
             assert_eq!(
                 include_buckets.len(),
                 (i * 64) as usize,
-                "The include request should return all 'foo' buckets, and not the missing term bucket",
+                "The include request should return all 'foo' buckets, and not the missing term \
+                 bucket",
             );
             assert!(include_buckets
                 .iter()
@@ -3007,7 +2996,8 @@ mod tests {
                 assert_eq!(
                     exclude_buckets.len(),
                     1,
-                    "The exclude request should exclude all 'foo' buckets, and only the missing term bucket",
+                    "The exclude request should exclude all 'foo' buckets, and only the missing \
+                     term bucket",
                 );
                 assert_eq!(exclude_buckets[0]["key"], "__NULL__");
             }

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -1225,7 +1225,7 @@ mod tests {
     use crate::aggregation::{AggregationLimitsGuard, DistributedAggregationCollector};
     use crate::indexer::NoMergePolicy;
     use crate::query::AllQuery;
-    use crate::schema::{IntoIpv6Addr, Schema, FAST, STORED, STRING, TEXT};
+    use crate::schema::{IntoIpv6Addr, Schema, FAST, INDEXED, STRING, TEXT};
     use crate::{Index, IndexWriter};
 
     #[test]
@@ -2924,10 +2924,11 @@ mod tests {
         n: u64,
     ) -> crate::Result<(Index, Aggregations)> {
         let mut schema_builder = Schema::builder();
-        let id_field = schema_builder.add_u64_field("id", STORED);
-        let title_field = schema_builder.add_text_field("title", TEXT | STORED | FAST);
+        let id_field = schema_builder.add_u64_field("id", INDEXED);
+        let title_field = schema_builder.add_text_field("title", TEXT | FAST);
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema.clone());
+        // set to one thread to guarantee all docs end up in the same segement
         let mut writer = index.writer_with_num_threads(1, 50_000_000)?;
 
         writer.add_document(doc!(

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -146,9 +146,7 @@ pub enum IncludeExcludeParam {
 
 impl Serialize for IncludeExcludeParam {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
+    where S: serde::Serializer {
         match self {
             IncludeExcludeParam::Regex(s) => serializer.serialize_str(s),
             IncludeExcludeParam::Values(v) => v.serialize(serializer),
@@ -159,9 +157,7 @@ impl Serialize for IncludeExcludeParam {
 // Custom deserializer to accept either a single string (regex) or an array of strings (values).
 impl<'de> Deserialize<'de> for IncludeExcludeParam {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
+    where D: serde::Deserializer<'de> {
         use serde::de::{self, SeqAccess, Visitor};
         struct IncludeExcludeVisitor;
 
@@ -173,30 +169,22 @@ impl<'de> Deserialize<'de> for IncludeExcludeParam {
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
+            where E: de::Error {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
+            where E: de::Error {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
+            where E: de::Error {
                 Ok(IncludeExcludeParam::Regex(v))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: SeqAccess<'de>,
-            {
+            where A: SeqAccess<'de> {
                 let mut values: Vec<String> = Vec::new();
                 while let Some(elem) = seq.next_element::<String>()? {
                     values.push(elem);

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -146,7 +146,9 @@ pub enum IncludeExcludeParam {
 
 impl Serialize for IncludeExcludeParam {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: serde::Serializer {
+    where
+        S: serde::Serializer,
+    {
         match self {
             IncludeExcludeParam::Regex(s) => serializer.serialize_str(s),
             IncludeExcludeParam::Values(v) => v.serialize(serializer),
@@ -157,7 +159,9 @@ impl Serialize for IncludeExcludeParam {
 // Custom deserializer to accept either a single string (regex) or an array of strings (values).
 impl<'de> Deserialize<'de> for IncludeExcludeParam {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: serde::Deserializer<'de> {
+    where
+        D: serde::Deserializer<'de>,
+    {
         use serde::de::{self, SeqAccess, Visitor};
         struct IncludeExcludeVisitor;
 
@@ -169,22 +173,30 @@ impl<'de> Deserialize<'de> for IncludeExcludeParam {
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where A: SeqAccess<'de> {
+            where
+                A: SeqAccess<'de>,
+            {
                 let mut values: Vec<String> = Vec::new();
                 while let Some(elem) = seq.next_element::<String>()? {
                     values.push(elem);
@@ -1213,7 +1225,7 @@ mod tests {
     use crate::aggregation::{AggregationLimitsGuard, DistributedAggregationCollector};
     use crate::indexer::NoMergePolicy;
     use crate::query::AllQuery;
-    use crate::schema::{IntoIpv6Addr, Schema, FAST, STRING};
+    use crate::schema::{IntoIpv6Addr, Schema, FAST, STORED, STRING, TEXT};
     use crate::{Index, IndexWriter};
 
     #[test]
@@ -2905,6 +2917,87 @@ mod tests {
         assert_eq!(agg_json["tags"]["doc_count_error_upper_bound"], 0);
         assert_eq!(agg_json["tags"]["sum_other_doc_count"], 0);
 
+        Ok(())
+    }
+
+    fn prep_index_and_agg_with_n_unique_terms_plus_one_null(
+        n: u64,
+    ) -> crate::Result<(Index, Aggregations)> {
+        let mut schema_builder = Schema::builder();
+        let id_field = schema_builder.add_u64_field("id", STORED);
+        let title_field = schema_builder.add_text_field("title", TEXT | STORED | FAST);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema.clone());
+        let mut writer = index.writer_with_num_threads(1, 50_000_000)?;
+
+        writer.add_document(doc!(
+            id_field => 0u64,
+        ))?;
+        for i in 1u64..=n {
+            let title = format!("foo{i}");
+            writer.add_document(doc!(
+                id_field => i,
+                title_field => title,
+            ))?;
+        }
+
+        writer.commit()?;
+
+        let agg_req: Aggregations = serde_json::from_value(json!({
+            "my_bool": {
+                "terms": {
+                    "field": "title",
+                    "include": "foo",
+                    "missing": "__NULL__",
+                }
+            }
+        }))?;
+
+        Ok((index, agg_req))
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regression_0() -> crate::Result<()> {
+        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(0)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regression_64() -> crate::Result<()> {
+        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(64)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regression_128() -> crate::Result<()> {
+        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(128)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regression_192() -> crate::Result<()> {
+        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(192)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regression_256() -> crate::Result<()> {
+        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(256)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Bug Overview
Under certain conditions, a `terms` aggregation request can cause a bounds-check panic. Those conditions are:
- The queried field must be a text field
- There must be a segment where the number of distinct terms in it's dictionary for the queried field is divisible by 64 (i.e.e where `count(term_dict.keys) % 64 == 0`)
- That same segment must contain at least one document that does not contain this field.
- The request contain a `missing` key that is a string.
- The request must contain an `include` or `exclude` filter.
For example:
```json
{
    "my_bool": {
        "terms": {
            "field": "title",
            "include": "foo",
            "missing": "__NULL__",
        }
    }
}
```
Check out the added tests in `src/aggregation/bucket/term_agg.rs` to see this in action

## How the bug happens
### Preparation
While preparing the aggregation nodes:
1) When we've provided a `missing` key, we derive a missing sentinel. For string keys this column's max value (which for string keys is always the number of terms in this segment) + 1.
2) for string columns only, we optionally prep an "allowed" `BitSet` for allowed term ids. (`build_allowed_term_ids_for_str` in `src/aggregation/agg_data.rs`)
    - If no `include` or `exclude` filter is provided, this just returns `None`, causing this check to be skipped down the line
    - Otherwise the bitset is initialized to be able to hold the exact number of terms in the segments term dictionary, and the bits are set to signify which terms are to be included in the results.

### Collection
If we have an "allowed" `BitSet`, filter documents against that. For each document, we check if the `BitSet` contains the documents term id. For documents without the field, this is the missing sentinel we derived earlier, minus 1 (to account for zero-based indexing): `(num_terms + 1) - 1`.However, the `BitSet`s size is only `num_terms`. Normally, this slips by without a problem, but if `num_terms % 64 == 0`, this will cause a panic.

### Why `BitSet` panics
`BitSet` is represented under the hood by a boxed slice of `u64`s. When you go to check a bit using `BitSet::contains`, it must determine which of those `u64`s the bit is in, and then the position within that `u64` of the bit. 

In cases where the number of terms is not divisible by 64, the `BitSet` must waste some bits. When we then look up the missing sentinel's bit, it happens to be one of those wasted bits, for which `BitSet` is happy to return the value of. For example, if the number of terms was 63:
```rust
let bitset_init_size = 63; // so BitSet's boxed slice has a length of 1, capable of holding 64 bits, term id [0, 62]
let missing_sentinel = 63; // num_terms + 1 - 1;
let byte_pos = missing_sentinel / 64; // 0 - within the valid slice
let bit_pos = missing_sentinel % 64; // 63 - hits the 1 wasted bit
```

But if the number of terms is indeed divisible by 64, then the `BitSet` is perfectly aligned to the byte boundary:
```rust
let bitset_init_size = 64; // so BitSet's boxed slice has a length of 1, capable of holding 64 bits, term ids [0, 63]
let missing_sentinel = 64; // num_terms + 1 - 1, 
let byte_pos = missing_sentinel / 64; // 1 - idx 1 >= slice length 1
let bit_pos = missing_sentinel % 64; // 0 
```
We try to access a byte outside of the bounds of the boxed slice, causing a panic from the bounds check to failing.

## Fixing it
The fix is simple. If we need to account for the missing sentinel, initialize the `BitSet` with capacity for one more bit.

## Tests
- Added a bunch of unit tests that hit these conditions. I ensured they failed without the fix, and that they now pass.
- All unit tests pass with the fix in place

## Other
- The investigation that led to finding this bug began with https://github.com/paradedb/paradedb/issues/4746. 