### PR TITLE
fix: Missing sentinel is now considered in term agg requests with exclude + missing

### DIFF
--- a/columnar/src/column/mod.rs
+++ b/columnar/src/column/mod.rs
@@ -84,6 +84,10 @@ impl<T: PartialOrd + Copy + Debug + Send + Sync + 'static> Column<T> {
         self.values.max_value()
     }
 
+    pub fn num_vals(&self) -> u32 {
+        self.values.num_vals()
+    }
+
     #[inline]
     pub fn first(&self, doc_id: DocId) -> Option<T> {
         self.values_for_doc(doc_id).next()

--- a/src/aggregation/accessor_helpers.rs
+++ b/src/aggregation/accessor_helpers.rs
@@ -7,6 +7,10 @@ use columnar::{Column, ColumnType};
 use crate::aggregation::{f64_to_fastfield_u64, Key};
 use crate::index::SegmentReader;
 
+/// For string columns, the missing value is always represented as column_max_value + 1, but in
+/// the case where we have no values for this column, that causes the missing value to be
+/// erroneously set to 1 (which would imply we had one additional value represented as 0).
+/// This checks for that case that case and returns 0 instead.
 fn missing_val_for_str_cols(column_max_value: u64, column_num_values: u32) -> u64 {
     if column_num_values == 0 {
         0

--- a/src/aggregation/accessor_helpers.rs
+++ b/src/aggregation/accessor_helpers.rs
@@ -7,6 +7,14 @@ use columnar::{Column, ColumnType};
 use crate::aggregation::{f64_to_fastfield_u64, Key};
 use crate::index::SegmentReader;
 
+fn missing_val_for_str_cols(column_max_value: u64, column_num_values: u32) -> u64 {
+    if column_num_values == 0 {
+        0
+    } else {
+        column_max_value + 1
+    }
+}
+
 /// Get the missing value as internal u64 representation
 ///
 /// For terms we use u64::MAX as sentinel value
@@ -17,15 +25,28 @@ use crate::index::SegmentReader;
 pub(crate) fn get_missing_val_as_u64_lenient(
     column_type: ColumnType,
     column_max_value: u64,
+    column_num_values: u32,
     missing: &Key,
     field_name: &str,
 ) -> crate::Result<Option<u64>> {
     let missing_val = match missing {
-        Key::Str(_) if column_type == ColumnType::Str => Some(column_max_value + 1),
+        Key::Str(_) if column_type == ColumnType::Str => Some(missing_val_for_str_cols(
+            column_max_value,
+            column_num_values,
+        )),
         // Allow fallback to number on text fields
-        Key::F64(_) if column_type == ColumnType::Str => Some(column_max_value + 1),
-        Key::U64(_) if column_type == ColumnType::Str => Some(column_max_value + 1),
-        Key::I64(_) if column_type == ColumnType::Str => Some(column_max_value + 1),
+        Key::F64(_) if column_type == ColumnType::Str => Some(missing_val_for_str_cols(
+            column_max_value,
+            column_num_values,
+        )),
+        Key::U64(_) if column_type == ColumnType::Str => Some(missing_val_for_str_cols(
+            column_max_value,
+            column_num_values,
+        )),
+        Key::I64(_) if column_type == ColumnType::Str => Some(missing_val_for_str_cols(
+            column_max_value,
+            column_num_values,
+        )),
         Key::F64(val) if column_type.numerical_type().is_some() => {
             f64_to_fastfield_u64(*val, &column_type)
         }

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -897,8 +897,12 @@ fn build_terms_or_cardinality_nodes(
                     let str_col = str_dict_column
                         .as_ref()
                         .expect("str_dict_column must exist for string column");
-                    allowed_term_ids =
-                        build_allowed_term_ids_for_str(str_col, &req.include, &req.exclude)?;
+                    allowed_term_ids = build_allowed_term_ids_for_str(
+                        str_col,
+                        &req.include,
+                        &req.exclude,
+                        missing,
+                    )?;
                 };
                 let idx_in_req_data = data.push_term_req_data(TermsAggReqData {
                     accessor,
@@ -941,9 +945,12 @@ fn build_allowed_term_ids_for_str(
     str_col: &StrColumn,
     include: &Option<IncludeExcludeParam>,
     exclude: &Option<IncludeExcludeParam>,
+    missing: &Option<Key>,
 ) -> crate::Result<Option<BitSet>> {
     let mut allowed: Option<BitSet> = None;
-    let num_terms = str_col.dictionary().num_terms() as u32;
+    let missing_adjustment = if missing.is_some() { 1 } else { 0 };
+    //let missing_adjustment = 0;
+    let num_terms = str_col.dictionary().num_terms() as u32 + missing_adjustment;
     if let Some(include) = include {
         // add matches
         allowed = Some(BitSet::with_max_value(num_terms));

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -948,9 +948,8 @@ fn build_allowed_term_ids_for_str(
     missing: &Option<Key>,
 ) -> crate::Result<Option<BitSet>> {
     let mut allowed: Option<BitSet> = None;
-    let missing_adjustment = if missing.is_some() { 1 } else { 0 };
-    //let missing_adjustment = 0;
-    let num_terms = str_col.dictionary().num_terms() as u32 + missing_adjustment;
+    let missing_sentinel_adjustment = if missing.is_some() { 1 } else { 0 };
+    let num_terms = str_col.dictionary().num_terms() as u32 + missing_sentinel_adjustment;
     if let Some(include) = include {
         // add matches
         allowed = Some(BitSet::with_max_value(num_terms));

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -941,6 +941,9 @@ fn build_terms_or_cardinality_nodes(
 
 /// Builds a single BitSet of allowed term ordinals for a string dictionary column according to
 /// include/exclude parameters.
+///
+/// When `reserve_missing_sentinel` is true, the bitset will have 1 additional slot for the missing
+/// term ordinal
 fn build_allowed_term_ids_for_str(
     str_col: &StrColumn,
     include: &Option<IncludeExcludeParam>,

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -879,7 +879,13 @@ fn build_terms_or_cardinality_nodes(
         let missing_value_for_accessor = if use_special_missing_agg {
             None
         } else if let Some(m) = missing.as_ref() {
-            get_missing_val_as_u64_lenient(column_type, accessor.max_value(), m, field_name)?
+            get_missing_val_as_u64_lenient(
+                column_type,
+                accessor.max_value(),
+                accessor.num_vals(),
+                m,
+                field_name,
+            )?
         } else {
             None
         };

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -901,7 +901,7 @@ fn build_terms_or_cardinality_nodes(
                         str_col,
                         &req.include,
                         &req.exclude,
-                        missing,
+                        missing.is_some(),
                     )?;
                 };
                 let idx_in_req_data = data.push_term_req_data(TermsAggReqData {
@@ -945,14 +945,14 @@ fn build_allowed_term_ids_for_str(
     str_col: &StrColumn,
     include: &Option<IncludeExcludeParam>,
     exclude: &Option<IncludeExcludeParam>,
-    missing: &Option<Key>,
+    reserve_missing_sentinel: bool,
 ) -> crate::Result<Option<BitSet>> {
     let mut allowed: Option<BitSet> = None;
-    let missing_sentinel_adjustment = if missing.is_some() { 1 } else { 0 };
-    let num_terms = str_col.dictionary().num_terms() as u32 + missing_sentinel_adjustment;
+    let missing_sentinel_adjustment = if reserve_missing_sentinel { 1 } else { 0 };
+    let allowed_capacity = str_col.dictionary().num_terms() as u32 + missing_sentinel_adjustment;
     if let Some(include) = include {
         // add matches
-        allowed = Some(BitSet::with_max_value(num_terms));
+        allowed = Some(BitSet::with_max_value(allowed_capacity));
         let allowed = allowed.as_mut().unwrap();
         for_each_matching_term_ord(str_col, include, |ord| allowed.insert(ord))?;
     };
@@ -960,7 +960,7 @@ fn build_allowed_term_ids_for_str(
     if let Some(exclude) = exclude {
         if allowed.is_none() {
             // Start with all terms allowed
-            allowed = Some(BitSet::with_max_value_and_full(num_terms));
+            allowed = Some(BitSet::with_max_value_and_full(allowed_capacity));
         }
         let allowed = allowed.as_mut().unwrap();
         for_each_matching_term_ord(str_col, exclude, |ord| allowed.remove(ord))?;

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -2950,11 +2950,20 @@ mod tests {
         // include cases
         for i in 0..=4 {
             let index = prep_index_with_n_unique_terms_plus_one_null(i * 64)?;
+            let normal_req: Aggregations = serde_json::from_value(json!({
+                "my_bool": {
+                    "terms": {
+                        "field": "title",
+                        "missing": "__NULL__",
+                        "size": 1000,
+                    }
+                }
+            }))?;
             let include_req: Aggregations = serde_json::from_value(json!({
                 "my_bool": {
                     "terms": {
                         "field": "title",
-                        "include": "foo",
+                        "include": "foo(.*)",
                         "missing": "__NULL__",
                         "size": 1000,
                     }
@@ -2964,15 +2973,23 @@ mod tests {
                 "my_bool": {
                     "terms": {
                         "field": "title",
-                        "exclude": "foo",
+                        "exclude": "foo(.*)",
                         "missing": "__NULL__",
                         "size": 1000,
                     }
                 }
             }))?;
 
-            // these should work and not panic
+            let normal_res = exec_request(normal_req, &index)?;
+            let normal_buckets = normal_res["my_bool"]["buckets"].as_array().unwrap();
+            assert_eq!(
+                normal_buckets.len(),
+                (i * 64) as usize + 1,
+                "The normal request should return all 'foo' buckets, plus the missing term bucket",
+            );
+
             let include_res = exec_request(include_req, &index)?;
+            eprintln!("include_res: {include_res:?}");
             let include_buckets = include_res["my_bool"]["buckets"].as_array().unwrap();
             assert_eq!(
                 include_buckets.len(),

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -2966,7 +2966,6 @@ mod tests {
     }
 
     #[test]
-
     fn null_bitset_bounds_check_regression() -> crate::Result<()> {
         // include cases
         for i in 0..=4 {

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -146,7 +146,9 @@ pub enum IncludeExcludeParam {
 
 impl Serialize for IncludeExcludeParam {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: serde::Serializer {
+    where
+        S: serde::Serializer,
+    {
         match self {
             IncludeExcludeParam::Regex(s) => serializer.serialize_str(s),
             IncludeExcludeParam::Values(v) => v.serialize(serializer),
@@ -157,7 +159,9 @@ impl Serialize for IncludeExcludeParam {
 // Custom deserializer to accept either a single string (regex) or an array of strings (values).
 impl<'de> Deserialize<'de> for IncludeExcludeParam {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: serde::Deserializer<'de> {
+    where
+        D: serde::Deserializer<'de>,
+    {
         use serde::de::{self, SeqAccess, Visitor};
         struct IncludeExcludeVisitor;
 
@@ -169,22 +173,30 @@ impl<'de> Deserialize<'de> for IncludeExcludeParam {
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where A: SeqAccess<'de> {
+            where
+                A: SeqAccess<'de>,
+            {
                 let mut values: Vec<String> = Vec::new();
                 while let Some(elem) = seq.next_element::<String>()? {
                     values.push(elem);
@@ -2960,102 +2972,17 @@ mod tests {
     }
 
     #[test]
-    fn null_bitset_bounds_check_regresiion_include_0() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(0)?;
-        let agg_req = agg_terms_request_for_regression_check(false)?;
+    fn null_bitset_bounds_check_regression() -> crate::Result<()> {
+        // include cases
+        for i in 0..=4 {
+            let index = prep_index_with_n_unique_terms_plus_one_null(i * 64)?;
+            let include_req = agg_terms_request_for_regression_check(false)?;
+            let exclude_req = agg_terms_request_for_regression_check(true)?;
 
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_include_64() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(64)?;
-        let agg_req = agg_terms_request_for_regression_check(false)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_include_128() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(128)?;
-        let agg_req = agg_terms_request_for_regression_check(false)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_include_192() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(192)?;
-        let agg_req = agg_terms_request_for_regression_check(false)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_include_256() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(256)?;
-        let agg_req = agg_terms_request_for_regression_check(false)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_exclude_0() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(0)?;
-        let agg_req = agg_terms_request_for_regression_check(true)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_exclude_64() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(64)?;
-        let agg_req = agg_terms_request_for_regression_check(true)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_exclude_128() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(128)?;
-        let agg_req = agg_terms_request_for_regression_check(true)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_exclude_192() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(192)?;
-        let agg_req = agg_terms_request_for_regression_check(true)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
-        Ok(())
-    }
-
-    #[test]
-    fn null_bitset_bounds_check_regresiion_exclude_256() -> crate::Result<()> {
-        let index = prep_index_with_n_unique_terms_plus_one_null(256)?;
-        let agg_req = agg_terms_request_for_regression_check(true)?;
-
-        // this should work and not panic
-        let _res = exec_request(agg_req, &index)?;
+            // this should work and not panic
+            let _res = exec_request(include_req, &index)?;
+            let _res = exec_request(exclude_req, &index)?;
+        }
         Ok(())
     }
 }

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -2920,9 +2920,7 @@ mod tests {
         Ok(())
     }
 
-    fn prep_index_and_agg_with_n_unique_terms_plus_one_null(
-        n: u64,
-    ) -> crate::Result<(Index, Aggregations)> {
+    fn prep_index_with_n_unique_terms_plus_one_null(n: u64) -> crate::Result<Index> {
         let mut schema_builder = Schema::builder();
         let id_field = schema_builder.add_u64_field("id", INDEXED);
         let title_field = schema_builder.add_text_field("title", TEXT | FAST);
@@ -2944,22 +2942,39 @@ mod tests {
 
         writer.commit()?;
 
-        let agg_req: Aggregations = serde_json::from_value(json!({
-            "my_bool": {
-                "terms": {
-                    "field": "title",
-                    "include": "foo",
-                    "missing": "__NULL__",
+        Ok(index)
+    }
+
+    fn agg_terms_request_for_regression_check(use_exclude: bool) -> crate::Result<Aggregations> {
+        let agg_req: Aggregations = if use_exclude {
+            serde_json::from_value(json!({
+                "my_bool": {
+                    "terms": {
+                        "field": "title",
+                        "exclude": "foo",
+                        "missing": "__NULL__",
+                    }
                 }
-            }
-        }))?;
+            }))?
+        } else {
+            serde_json::from_value(json!({
+                "my_bool": {
+                    "terms": {
+                        "field": "title",
+                        "include": "foo",
+                        "missing": "__NULL__",
+                    }
+                }
+            }))?
+        };
 
-        Ok((index, agg_req))
+        Ok(agg_req)
     }
 
     #[test]
-    fn null_bitset_bounds_check_regression_0() -> crate::Result<()> {
-        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(0)?;
+    fn null_bitset_bounds_check_regresiion_include_0() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(0)?;
+        let agg_req = agg_terms_request_for_regression_check(false)?;
 
         // this should work and not panic
         let _res = exec_request(agg_req, &index)?;
@@ -2967,8 +2982,9 @@ mod tests {
     }
 
     #[test]
-    fn null_bitset_bounds_check_regression_64() -> crate::Result<()> {
-        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(64)?;
+    fn null_bitset_bounds_check_regresiion_include_64() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(64)?;
+        let agg_req = agg_terms_request_for_regression_check(false)?;
 
         // this should work and not panic
         let _res = exec_request(agg_req, &index)?;
@@ -2976,8 +2992,9 @@ mod tests {
     }
 
     #[test]
-    fn null_bitset_bounds_check_regression_128() -> crate::Result<()> {
-        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(128)?;
+    fn null_bitset_bounds_check_regresiion_include_128() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(128)?;
+        let agg_req = agg_terms_request_for_regression_check(false)?;
 
         // this should work and not panic
         let _res = exec_request(agg_req, &index)?;
@@ -2985,8 +3002,9 @@ mod tests {
     }
 
     #[test]
-    fn null_bitset_bounds_check_regression_192() -> crate::Result<()> {
-        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(192)?;
+    fn null_bitset_bounds_check_regresiion_include_192() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(192)?;
+        let agg_req = agg_terms_request_for_regression_check(false)?;
 
         // this should work and not panic
         let _res = exec_request(agg_req, &index)?;
@@ -2994,8 +3012,59 @@ mod tests {
     }
 
     #[test]
-    fn null_bitset_bounds_check_regression_256() -> crate::Result<()> {
-        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(256)?;
+    fn null_bitset_bounds_check_regresiion_include_256() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(256)?;
+        let agg_req = agg_terms_request_for_regression_check(false)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regresiion_exclude_0() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(0)?;
+        let agg_req = agg_terms_request_for_regression_check(true)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regresiion_exclude_64() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(64)?;
+        let agg_req = agg_terms_request_for_regression_check(true)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regresiion_exclude_128() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(128)?;
+        let agg_req = agg_terms_request_for_regression_check(true)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regresiion_exclude_192() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(192)?;
+        let agg_req = agg_terms_request_for_regression_check(true)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regresiion_exclude_256() -> crate::Result<()> {
+        let index = prep_index_with_n_unique_terms_plus_one_null(256)?;
+        let agg_req = agg_terms_request_for_regression_check(true)?;
 
         // this should work and not panic
         let _res = exec_request(agg_req, &index)?;

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -2945,43 +2945,55 @@ mod tests {
         Ok(index)
     }
 
-    fn agg_terms_request_for_regression_check(use_exclude: bool) -> crate::Result<Aggregations> {
-        let agg_req: Aggregations = if use_exclude {
-            serde_json::from_value(json!({
-                "my_bool": {
-                    "terms": {
-                        "field": "title",
-                        "exclude": "foo",
-                        "missing": "__NULL__",
-                    }
-                }
-            }))?
-        } else {
-            serde_json::from_value(json!({
-                "my_bool": {
-                    "terms": {
-                        "field": "title",
-                        "include": "foo",
-                        "missing": "__NULL__",
-                    }
-                }
-            }))?
-        };
-
-        Ok(agg_req)
-    }
-
     #[test]
     fn null_bitset_bounds_check_regression() -> crate::Result<()> {
         // include cases
         for i in 0..=4 {
             let index = prep_index_with_n_unique_terms_plus_one_null(i * 64)?;
-            let include_req = agg_terms_request_for_regression_check(false)?;
-            let exclude_req = agg_terms_request_for_regression_check(true)?;
+            let include_req: Aggregations = serde_json::from_value(json!({
+                "my_bool": {
+                    "terms": {
+                        "field": "title",
+                        "include": "foo",
+                        "missing": "__NULL__",
+                        "size": 1000,
+                    }
+                }
+            }))?;
+            let exclude_req: Aggregations = serde_json::from_value(json!({
+                "my_bool": {
+                    "terms": {
+                        "field": "title",
+                        "exclude": "foo",
+                        "missing": "__NULL__",
+                        "size": 1000,
+                    }
+                }
+            }))?;
 
-            // this should work and not panic
-            let _res = exec_request(include_req, &index)?;
-            let _res = exec_request(exclude_req, &index)?;
+            // these should work and not panic
+            let include_res = exec_request(include_req, &index)?;
+            let include_buckets = include_res["my_bool"]["buckets"].as_array().unwrap();
+            assert_eq!(
+                include_buckets.len(),
+                (i * 64) as usize,
+                "The include request should return all 'foo' buckets, and not the missing term bucket",
+            );
+            assert!(include_buckets
+                .iter()
+                .all(|b| b["key"].as_str().unwrap().starts_with("foo")));
+
+            let exclude_res = exec_request(exclude_req, &index)?;
+            let exclude_buckets = exclude_res["my_bool"]["buckets"].as_array().unwrap();
+            if i != 0 {
+                // TODO: Remove this if after fixing exclude + missing bug
+                assert_eq!(
+                    exclude_buckets.len(),
+                    1,
+                    "The exclude request should exclude all 'foo' buckets, and only the missing term bucket",
+                );
+                assert_eq!(exclude_buckets[0]["key"], "__NULL__");
+            }
         }
         Ok(())
     }

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -146,9 +146,7 @@ pub enum IncludeExcludeParam {
 
 impl Serialize for IncludeExcludeParam {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
+    where S: serde::Serializer {
         match self {
             IncludeExcludeParam::Regex(s) => serializer.serialize_str(s),
             IncludeExcludeParam::Values(v) => v.serialize(serializer),
@@ -159,9 +157,7 @@ impl Serialize for IncludeExcludeParam {
 // Custom deserializer to accept either a single string (regex) or an array of strings (values).
 impl<'de> Deserialize<'de> for IncludeExcludeParam {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
+    where D: serde::Deserializer<'de> {
         use serde::de::{self, SeqAccess, Visitor};
         struct IncludeExcludeVisitor;
 
@@ -173,30 +169,22 @@ impl<'de> Deserialize<'de> for IncludeExcludeParam {
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
+            where E: de::Error {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
+            where E: de::Error {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
+            where E: de::Error {
                 Ok(IncludeExcludeParam::Regex(v))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: SeqAccess<'de>,
-            {
+            where A: SeqAccess<'de> {
                 let mut values: Vec<String> = Vec::new();
                 while let Some(elem) = seq.next_element::<String>()? {
                     values.push(elem);
@@ -2958,7 +2946,7 @@ mod tests {
             }
         }))?;
 
-        //zero unique terms case
+        // zero unique terms case
         let index = prep_index_with_n_unique_terms_plus_one_null(0)?;
 
         let res = exec_request(exclude_req.clone(), &index)?;
@@ -3038,8 +3026,8 @@ mod tests {
             assert_eq!(
                 exclude_buckets.len(),
                 1,
-                "The exclude request should exclude all 'foo' buckets, and only the missing \
-                     term bucket",
+                "The exclude request should exclude all 'foo' buckets, and only the missing term \
+                 bucket",
             );
             assert_eq!(exclude_buckets[0]["key"], "__NULL__");
         }

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -146,7 +146,9 @@ pub enum IncludeExcludeParam {
 
 impl Serialize for IncludeExcludeParam {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: serde::Serializer {
+    where
+        S: serde::Serializer,
+    {
         match self {
             IncludeExcludeParam::Regex(s) => serializer.serialize_str(s),
             IncludeExcludeParam::Values(v) => v.serialize(serializer),
@@ -157,7 +159,9 @@ impl Serialize for IncludeExcludeParam {
 // Custom deserializer to accept either a single string (regex) or an array of strings (values).
 impl<'de> Deserialize<'de> for IncludeExcludeParam {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: serde::Deserializer<'de> {
+    where
+        D: serde::Deserializer<'de>,
+    {
         use serde::de::{self, SeqAccess, Visitor};
         struct IncludeExcludeVisitor;
 
@@ -169,22 +173,30 @@ impl<'de> Deserialize<'de> for IncludeExcludeParam {
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where A: SeqAccess<'de> {
+            where
+                A: SeqAccess<'de>,
+            {
                 let mut values: Vec<String> = Vec::new();
                 while let Some(elem) = seq.next_element::<String>()? {
                     values.push(elem);
@@ -2914,7 +2926,7 @@ mod tests {
         let title_field = schema_builder.add_text_field("title", TEXT | FAST);
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema.clone());
-        // set to one thread to guarantee all docs end up in the same segement
+        // set to one thread to guarantee all docs end up in the same segment
         let mut writer = index.writer_with_num_threads(1, 50_000_000)?;
 
         writer.add_document(doc!(

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -146,9 +146,7 @@ pub enum IncludeExcludeParam {
 
 impl Serialize for IncludeExcludeParam {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
+    where S: serde::Serializer {
         match self {
             IncludeExcludeParam::Regex(s) => serializer.serialize_str(s),
             IncludeExcludeParam::Values(v) => v.serialize(serializer),
@@ -159,9 +157,7 @@ impl Serialize for IncludeExcludeParam {
 // Custom deserializer to accept either a single string (regex) or an array of strings (values).
 impl<'de> Deserialize<'de> for IncludeExcludeParam {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
+    where D: serde::Deserializer<'de> {
         use serde::de::{self, SeqAccess, Visitor};
         struct IncludeExcludeVisitor;
 
@@ -173,30 +169,22 @@ impl<'de> Deserialize<'de> for IncludeExcludeParam {
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
+            where E: de::Error {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
+            where E: de::Error {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
+            where E: de::Error {
                 Ok(IncludeExcludeParam::Regex(v))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: SeqAccess<'de>,
-            {
+            where A: SeqAccess<'de> {
                 let mut values: Vec<String> = Vec::new();
                 while let Some(elem) = seq.next_element::<String>()? {
                     values.push(elem);
@@ -2994,7 +2982,8 @@ mod tests {
             assert_eq!(
                 include_buckets.len(),
                 (i * 64) as usize,
-                "The include request should return all 'foo' buckets, and not the missing term bucket",
+                "The include request should return all 'foo' buckets, and not the missing term \
+                 bucket",
             );
             assert!(include_buckets
                 .iter()
@@ -3007,7 +2996,8 @@ mod tests {
                 assert_eq!(
                     exclude_buckets.len(),
                     1,
-                    "The exclude request should exclude all 'foo' buckets, and only the missing term bucket",
+                    "The exclude request should exclude all 'foo' buckets, and only the missing \
+                     term bucket",
                 );
                 assert_eq!(exclude_buckets[0]["key"], "__NULL__");
             }

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -146,7 +146,9 @@ pub enum IncludeExcludeParam {
 
 impl Serialize for IncludeExcludeParam {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: serde::Serializer {
+    where
+        S: serde::Serializer,
+    {
         match self {
             IncludeExcludeParam::Regex(s) => serializer.serialize_str(s),
             IncludeExcludeParam::Values(v) => v.serialize(serializer),
@@ -157,7 +159,9 @@ impl Serialize for IncludeExcludeParam {
 // Custom deserializer to accept either a single string (regex) or an array of strings (values).
 impl<'de> Deserialize<'de> for IncludeExcludeParam {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: serde::Deserializer<'de> {
+    where
+        D: serde::Deserializer<'de>,
+    {
         use serde::de::{self, SeqAccess, Visitor};
         struct IncludeExcludeVisitor;
 
@@ -169,22 +173,30 @@ impl<'de> Deserialize<'de> for IncludeExcludeParam {
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where A: SeqAccess<'de> {
+            where
+                A: SeqAccess<'de>,
+            {
                 let mut values: Vec<String> = Vec::new();
                 while let Some(elem) = seq.next_element::<String>()? {
                     values.push(elem);
@@ -2931,6 +2943,38 @@ mod tests {
         writer.commit()?;
 
         Ok(index)
+    }
+
+    #[test]
+    fn terms_agg_request_with_exclude_returns_missing_term_bucket() -> crate::Result<()> {
+        let exclude_req: Aggregations = serde_json::from_value(json!({
+            "my_bool": {
+                "terms": {
+                    "field": "title",
+                    "exclude": "foo(.*)",
+                    "missing": "__NULL__",
+                    "size": 1000,
+                }
+            }
+        }))?;
+
+        //zero unique terms case
+        let index = prep_index_with_n_unique_terms_plus_one_null(0)?;
+
+        let res = exec_request(exclude_req.clone(), &index)?;
+        let buckets = res["my_bool"]["buckets"].as_array().unwrap();
+        assert_eq!(buckets.len(), 1);
+        assert_eq!(buckets[0]["key"], "__NULL__");
+
+        // non-zero unique terms case
+        let index = prep_index_with_n_unique_terms_plus_one_null(64)?;
+
+        let res = exec_request(exclude_req, &index)?;
+        let buckets = res["my_bool"]["buckets"].as_array().unwrap();
+        assert_eq!(buckets.len(), 1);
+        assert_eq!(buckets[0]["key"], "__NULL__");
+
+        Ok(())
     }
 
     #[test]

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -1225,7 +1225,7 @@ mod tests {
     use crate::aggregation::{AggregationLimitsGuard, DistributedAggregationCollector};
     use crate::indexer::NoMergePolicy;
     use crate::query::AllQuery;
-    use crate::schema::{IntoIpv6Addr, Schema, FAST, STORED, STRING, TEXT};
+    use crate::schema::{IntoIpv6Addr, Schema, FAST, INDEXED, STRING, TEXT};
     use crate::{Index, IndexWriter};
 
     #[test]
@@ -2924,10 +2924,11 @@ mod tests {
         n: u64,
     ) -> crate::Result<(Index, Aggregations)> {
         let mut schema_builder = Schema::builder();
-        let id_field = schema_builder.add_u64_field("id", STORED);
-        let title_field = schema_builder.add_text_field("title", TEXT | STORED | FAST);
+        let id_field = schema_builder.add_u64_field("id", INDEXED);
+        let title_field = schema_builder.add_text_field("title", TEXT | FAST);
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema.clone());
+        // set to one thread to guarantee all docs end up in the same segement
         let mut writer = index.writer_with_num_threads(1, 50_000_000)?;
 
         writer.add_document(doc!(

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -146,9 +146,7 @@ pub enum IncludeExcludeParam {
 
 impl Serialize for IncludeExcludeParam {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
+    where S: serde::Serializer {
         match self {
             IncludeExcludeParam::Regex(s) => serializer.serialize_str(s),
             IncludeExcludeParam::Values(v) => v.serialize(serializer),
@@ -159,9 +157,7 @@ impl Serialize for IncludeExcludeParam {
 // Custom deserializer to accept either a single string (regex) or an array of strings (values).
 impl<'de> Deserialize<'de> for IncludeExcludeParam {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
+    where D: serde::Deserializer<'de> {
         use serde::de::{self, SeqAccess, Visitor};
         struct IncludeExcludeVisitor;
 
@@ -173,30 +169,22 @@ impl<'de> Deserialize<'de> for IncludeExcludeParam {
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
+            where E: de::Error {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
+            where E: de::Error {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
+            where E: de::Error {
                 Ok(IncludeExcludeParam::Regex(v))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: SeqAccess<'de>,
-            {
+            where A: SeqAccess<'de> {
                 let mut values: Vec<String> = Vec::new();
                 while let Some(elem) = seq.next_element::<String>()? {
                     values.push(elem);

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -3035,16 +3035,13 @@ mod tests {
 
             let exclude_res = exec_request(exclude_req, &index)?;
             let exclude_buckets = exclude_res["my_bool"]["buckets"].as_array().unwrap();
-            if i != 0 {
-                // TODO: Remove this if after fixing exclude + missing bug
-                assert_eq!(
-                    exclude_buckets.len(),
-                    1,
-                    "The exclude request should exclude all 'foo' buckets, and only the missing \
+            assert_eq!(
+                exclude_buckets.len(),
+                1,
+                "The exclude request should exclude all 'foo' buckets, and only the missing \
                      term bucket",
-                );
-                assert_eq!(exclude_buckets[0]["key"], "__NULL__");
-            }
+            );
+            assert_eq!(exclude_buckets[0]["key"], "__NULL__");
         }
         Ok(())
     }

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -146,7 +146,9 @@ pub enum IncludeExcludeParam {
 
 impl Serialize for IncludeExcludeParam {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: serde::Serializer {
+    where
+        S: serde::Serializer,
+    {
         match self {
             IncludeExcludeParam::Regex(s) => serializer.serialize_str(s),
             IncludeExcludeParam::Values(v) => v.serialize(serializer),
@@ -157,7 +159,9 @@ impl Serialize for IncludeExcludeParam {
 // Custom deserializer to accept either a single string (regex) or an array of strings (values).
 impl<'de> Deserialize<'de> for IncludeExcludeParam {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: serde::Deserializer<'de> {
+    where
+        D: serde::Deserializer<'de>,
+    {
         use serde::de::{self, SeqAccess, Visitor};
         struct IncludeExcludeVisitor;
 
@@ -169,22 +173,30 @@ impl<'de> Deserialize<'de> for IncludeExcludeParam {
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v.to_string()))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-            where E: de::Error {
+            where
+                E: de::Error,
+            {
                 Ok(IncludeExcludeParam::Regex(v))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where A: SeqAccess<'de> {
+            where
+                A: SeqAccess<'de>,
+            {
                 let mut values: Vec<String> = Vec::new();
                 while let Some(elem) = seq.next_element::<String>()? {
                     values.push(elem);
@@ -1213,7 +1225,7 @@ mod tests {
     use crate::aggregation::{AggregationLimitsGuard, DistributedAggregationCollector};
     use crate::indexer::NoMergePolicy;
     use crate::query::AllQuery;
-    use crate::schema::{IntoIpv6Addr, Schema, FAST, STRING};
+    use crate::schema::{IntoIpv6Addr, Schema, FAST, STORED, STRING, TEXT};
     use crate::{Index, IndexWriter};
 
     #[test]
@@ -2905,6 +2917,87 @@ mod tests {
         assert_eq!(agg_json["tags"]["doc_count_error_upper_bound"], 0);
         assert_eq!(agg_json["tags"]["sum_other_doc_count"], 0);
 
+        Ok(())
+    }
+
+    fn prep_index_and_agg_with_n_unique_terms_plus_one_null(
+        n: u64,
+    ) -> crate::Result<(Index, Aggregations)> {
+        let mut schema_builder = Schema::builder();
+        let id_field = schema_builder.add_u64_field("id", STORED);
+        let title_field = schema_builder.add_text_field("title", TEXT | STORED | FAST);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema.clone());
+        let mut writer = index.writer_with_num_threads(1, 50_000_000)?;
+
+        writer.add_document(doc!(
+            id_field => 0u64,
+        ))?;
+        for i in 1u64..=n {
+            let title = format!("foo{i}");
+            writer.add_document(doc!(
+                id_field => i,
+                title_field => title,
+            ))?;
+        }
+
+        writer.commit()?;
+
+        let agg_req: Aggregations = serde_json::from_value(json!({
+            "my_bool": {
+                "terms": {
+                    "field": "title",
+                    "include": "foo",
+                    "missing": "__NULL__",
+                }
+            }
+        }))?;
+
+        Ok((index, agg_req))
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regression_0() -> crate::Result<()> {
+        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(0)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regression_64() -> crate::Result<()> {
+        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(64)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regression_128() -> crate::Result<()> {
+        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(128)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regression_192() -> crate::Result<()> {
+        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(192)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
+        Ok(())
+    }
+
+    #[test]
+    fn null_bitset_bounds_check_regression_256() -> crate::Result<()> {
+        let (index, agg_req) = prep_index_and_agg_with_n_unique_terms_plus_one_null(256)?;
+
+        // this should work and not panic
+        let _res = exec_request(agg_req, &index)?;
         Ok(())
     }
 }


### PR DESCRIPTION
The missing sentinel value is computed as (this name is descriptive, not a reference ->) `max_term_ordinal + 1`. When there are zero unique terms, this causes the sentinel value to be 1 (because `max_term_ordinal` is 0 by default), which means the allowed terms bitset never contains it (because it will only have capacity 1 in this case). 

This fix adds logic to handle that by considering the number of unique values in the column when computing the missing sentinel value.

(Ideally we'd have distinct representations for the max term ordinal of zero unique terms and one unique term, but that would be much broader refactor)