### PR TITLE
feat: New BlockwiseLinearV2 u64 column codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,6 +1772,7 @@ dependencies = [
  "fastdivide",
  "itertools 0.14.0",
  "more-asserts",
+ "parking_lot",
  "proptest",
  "rand 0.9.2",
  "serde",

--- a/columnar/Cargo.toml
+++ b/columnar/Cargo.toml
@@ -18,6 +18,7 @@ common = { version= "0.10", path = "../common", package = "tantivy-common" }
 tantivy-bitpacker = { version= "0.9", path = "../bitpacker/" }
 serde = "1.0.152"
 downcast-rs = "2.0.1"
+parking_lot = "0.12.4"
 
 [dev-dependencies]
 proptest = "1"

--- a/columnar/src/column/serialize.rs
+++ b/columnar/src/column/serialize.rs
@@ -33,7 +33,7 @@ pub fn serialize_column_mappable_to_u64<T: MonotonicallyMappableToU64>(
     let column_index_num_bytes = serialize_column_index(column_index, output)?;
     serialize_u64_based_column_values(
         column_values,
-        &[CodecType::Bitpacked, CodecType::BlockwiseLinear],
+        &[CodecType::Bitpacked, CodecType::BlockwiseLinearV2],
         output,
     )?;
     output.write_all(&column_index_num_bytes.to_le_bytes())?;

--- a/columnar/src/column/serialize.rs
+++ b/columnar/src/column/serialize.rs
@@ -32,11 +32,7 @@ pub fn serialize_column_mappable_to_u64<T: MonotonicallyMappableToU64>(
     output: &mut impl Write,
 ) -> io::Result<()> {
     let column_index_num_bytes = serialize_column_index(column_index, output)?;
-    serialize_u64_based_column_values(
-        column_values,
-        codec_types,
-        output,
-    )?;
+    serialize_u64_based_column_values(column_values, codec_types, output)?;
     output.write_all(&column_index_num_bytes.to_le_bytes())?;
     Ok(())
 }

--- a/columnar/src/column/serialize.rs
+++ b/columnar/src/column/serialize.rs
@@ -28,12 +28,13 @@ pub fn serialize_column_mappable_to_u128<T: MonotonicallyMappableToU128>(
 pub fn serialize_column_mappable_to_u64<T: MonotonicallyMappableToU64>(
     column_index: SerializableColumnIndex<'_>,
     column_values: &impl Iterable<T>,
+    codec_types: &[CodecType],
     output: &mut impl Write,
 ) -> io::Result<()> {
     let column_index_num_bytes = serialize_column_index(column_index, output)?;
     serialize_u64_based_column_values(
         column_values,
-        &[CodecType::Bitpacked, CodecType::BlockwiseLinearV2],
+        codec_types,
         output,
     )?;
     output.write_all(&column_index_num_bytes.to_le_bytes())?;

--- a/columnar/src/column_index/multivalued_index.rs
+++ b/columnar/src/column_index/multivalued_index.rs
@@ -381,7 +381,7 @@ mod tests {
         columnar_writer.record_numerical(5, "full", u64::MAX);
 
         let mut wrt: Vec<u8> = Vec::new();
-        columnar_writer.serialize(7, None, &mut wrt).unwrap();
+        columnar_writer.serialize(7, None, &crate::DEFAULT_CODEC_TYPES, &mut wrt).unwrap();
 
         let reader = ColumnarReader::open(wrt).unwrap();
         // Open the column as u64

--- a/columnar/src/column_index/multivalued_index.rs
+++ b/columnar/src/column_index/multivalued_index.rs
@@ -381,7 +381,9 @@ mod tests {
         columnar_writer.record_numerical(5, "full", u64::MAX);
 
         let mut wrt: Vec<u8> = Vec::new();
-        columnar_writer.serialize(7, None, &crate::DEFAULT_CODEC_TYPES, &mut wrt).unwrap();
+        columnar_writer
+            .serialize(7, None, &crate::DEFAULT_CODEC_TYPES, &mut wrt)
+            .unwrap();
 
         let reader = ColumnarReader::open(wrt).unwrap();
         // Open the column as u64

--- a/columnar/src/column_index/optional_index/tests.rs
+++ b/columnar/src/column_index/optional_index/tests.rs
@@ -16,7 +16,7 @@ fn test_optional_index_with_num_docs(num_docs: u32) {
     dataframe_writer.record_numerical(100, "score", 80i64);
     let mut buffer: Vec<u8> = Vec::new();
     dataframe_writer
-        .serialize(num_docs, None, &mut buffer)
+        .serialize(num_docs, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
         .unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);

--- a/columnar/src/column_values/mod.rs
+++ b/columnar/src/column_values/mod.rs
@@ -27,7 +27,8 @@ mod monotonic_column;
 pub(crate) use merge::MergedColumnValues;
 pub use stats::ColumnStats;
 pub use u64_based::{
-    ALL_U64_CODEC_TYPES, CodecType, load_u64_based_column_values, serialize_u64_based_column_values,
+    ALL_U64_CODEC_TYPES, BlockwiseLinearV2Codec, BlockwiseLinearV2Reader, CodecType, ColumnCodec,
+    load_u64_based_column_values, serialize_u64_based_column_values,
 };
 pub use u128_based::{
     CompactSpaceU64Accessor, open_u128_as_compact_u64, open_u128_mapped,

--- a/columnar/src/column_values/mod.rs
+++ b/columnar/src/column_values/mod.rs
@@ -27,8 +27,8 @@ mod monotonic_column;
 pub(crate) use merge::MergedColumnValues;
 pub use stats::ColumnStats;
 pub use u64_based::{
-    ALL_U64_CODEC_TYPES, BlockwiseLinearV2Codec, BlockwiseLinearV2Reader, CodecType, ColumnCodec,
-    load_u64_based_column_values, serialize_u64_based_column_values,
+    ALL_U64_CODEC_TYPES, CodecType, ColumnCodec, load_u64_based_column_values,
+    serialize_u64_based_column_values,
 };
 pub use u128_based::{
     CompactSpaceU64Accessor, open_u128_as_compact_u64, open_u128_mapped,

--- a/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
@@ -70,6 +70,8 @@ impl BinarySerializable for BlockMeta {
     fn serialize<W: Write + ?Sized>(&self, writer: &mut W) -> io::Result<()> {
         // We serialize slope/intercept individually instead of `line.serialize()`
         // to ensure fixed-sized encoding (the latter uses varints).
+        // We do manual serialization instead of `line.serialize()`
+        // to ensure everything is fixed-sized (the latter uses varints).
         self.line.slope.serialize(writer)?;
         self.line.intercept.serialize(writer)?;
         self.bit_width.serialize(writer)?;

--- a/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
@@ -38,7 +38,10 @@ use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnS
 use crate::column_values::{ColumnValues, VecColumn};
 
 const BLOCK_SIZE: u32 = 512u32;
-const DATA_OFFSET_UNIT: usize = (BLOCK_SIZE / 8) as usize; // 64 bytes
+/// Bytes per block when bit_width=1: one bit per value × BLOCK_SIZE values / 8 bits-per-byte.
+/// Each additional bit of `bit_width` adds another `BYTES_PER_BLOCK_BIT` bytes.
+/// `data_offset` is stored in these units so a u32 can address up to ~256GB.
+const BYTES_PER_BLOCK_BIT: usize = (BLOCK_SIZE / 8) as usize; // 64
 
 /// Fixed-size footer entry: slope(8) + intercept(8) + bit_width(1) + data_offset(4) = 21 bytes.
 /// `data_offset` is stored in units of 64 bytes (BLOCK_SIZE / 8), not raw bytes,
@@ -60,8 +63,8 @@ impl BlockMeta {
     /// Returns the byte range of this block's bitpacked data within the data region.
     #[inline(always)]
     fn data_byte_range(&self, data_region_len: usize) -> std::ops::Range<usize> {
-        let start = self.data_offset as usize * DATA_OFFSET_UNIT;
-        let end = (start + self.bit_width as usize * DATA_OFFSET_UNIT).min(data_region_len);
+        let start = self.data_offset as usize * BYTES_PER_BLOCK_BIT;
+        let end = (start + self.bit_width as usize * BYTES_PER_BLOCK_BIT).min(data_region_len);
         start..end
     }
 }

--- a/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
@@ -56,8 +56,20 @@ const BLOCK_META_SIZE: usize = <u64 as FixedSize>::SIZE_IN_BYTES  // slope
     + <u8 as FixedSize>::SIZE_IN_BYTES   // bit_width
     + <u32 as FixedSize>::SIZE_IN_BYTES; // data_offset
 
+impl BlockMeta {
+    /// Returns the byte range of this block's bitpacked data within the data region.
+    #[inline(always)]
+    fn data_byte_range(&self, data_region_len: usize) -> std::ops::Range<usize> {
+        let start = self.data_offset as usize * DATA_OFFSET_UNIT;
+        let end = (start + self.bit_width as usize * DATA_OFFSET_UNIT).min(data_region_len);
+        start..end
+    }
+}
+
 impl BinarySerializable for BlockMeta {
     fn serialize<W: Write + ?Sized>(&self, writer: &mut W) -> io::Result<()> {
+        // We serialize slope/intercept individually instead of `line.serialize()`
+        // to ensure fixed-sized encoding (the latter uses varints).
         self.line.slope.serialize(writer)?;
         self.line.intercept.serialize(writer)?;
         self.bit_width.serialize(writer)?;
@@ -84,16 +96,15 @@ impl FixedSize for BlockMeta {
 
 /// Parse a block metadata entry from a byte slice.
 #[inline(always)]
-fn parse_block_meta(entry: &[u8]) -> BlockMeta {
-    let mut cursor = entry;
-    BlockMeta::deserialize(&mut cursor).expect("failed to parse block meta")
+fn parse_block_meta(mut entry: &[u8]) -> BlockMeta {
+    BlockMeta::deserialize(&mut entry).expect("failed to parse block meta")
 }
 
 fn compute_num_blocks(num_vals: u32) -> u32 {
     num_vals.div_ceil(BLOCK_SIZE)
 }
 
-pub struct BlockwiseLinearV2Estimator {
+pub(crate) struct BlockwiseLinearV2Estimator {
     block: Vec<u64>,
     values_num_bytes: u64,
     num_blocks: u64,
@@ -125,7 +136,7 @@ impl BlockwiseLinearV2Estimator {
             max_value = val.max(max_value);
         }
         let bit_width = compute_num_bits(max_value) as usize;
-        self.values_num_bytes += (bit_width * self.block.len() + 7) as u64 / 8;
+        self.values_num_bytes += (bit_width * self.block.len()).div_ceil(8) as u64;
         self.num_blocks += 1;
     }
 }
@@ -221,7 +232,7 @@ impl ColumnCodecEstimator for BlockwiseLinearV2Estimator {
     }
 }
 
-pub struct BlockwiseLinearV2Codec;
+pub(crate) struct BlockwiseLinearV2Codec;
 
 impl ColumnCodec<u64> for BlockwiseLinearV2Codec {
     type ColumnValues = BlockwiseLinearV2Reader;
@@ -275,7 +286,7 @@ impl BlockCache {
 }
 
 #[derive(Clone)]
-pub struct BlockwiseLinearV2Reader {
+pub(crate) struct BlockwiseLinearV2Reader {
     footer: FileSlice,
     data: FileSlice,
     stats: ColumnStats,
@@ -303,15 +314,13 @@ impl ColumnValues for BlockwiseLinearV2Reader {
         let mut cache = self.cache.0.lock();
         if cache.block_id != block_id {
             let meta = self.block_meta(block_id as usize);
-            let data_start = meta.data_offset as usize * DATA_OFFSET_UNIT;
-            let data_len = meta.bit_width as usize * DATA_OFFSET_UNIT;
-            let data_end = (data_start + data_len).min(self.data.len());
+            let range = meta.data_byte_range(self.data.len());
             cache.block_id = block_id;
             cache.line = meta.line;
             cache.bit_unpacker = BitUnpacker::new(meta.bit_width);
             cache.data = self
                 .data
-                .slice(data_start..data_end)
+                .slice(range)
                 .read_bytes()
                 .expect("failed to read block data");
         }
@@ -359,12 +368,10 @@ impl ColumnValues for BlockwiseLinearV2Reader {
             let local_off = (block_id - first_block) * BLOCK_META_SIZE;
             let meta = parse_block_meta(&footer_bytes[local_off..local_off + BLOCK_META_SIZE]);
 
-            let data_start = meta.data_offset as usize * DATA_OFFSET_UNIT;
-            let data_len = meta.bit_width as usize * DATA_OFFSET_UNIT;
-            let data_end = (data_start + data_len).min(self.data.len());
+            let range = meta.data_byte_range(self.data.len());
             let data = self
                 .data
-                .slice(data_start..data_end)
+                .slice(range)
                 .read_bytes()
                 .expect("failed to read block data");
             let bit_unpacker = BitUnpacker::new(meta.bit_width);

--- a/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
@@ -1,3 +1,30 @@
+//! BlockwiseLinearV2 — a u64 column codec optimised for lazy, on-demand access.
+//!
+//! Like BlockwiseLinear (V1), values are split into fixed-size blocks of 512 rows.
+//! Each block fits a linear approximation and bitpacks the residuals. The key
+//! difference is in the footer layout and load strategy:
+//!
+//! **Fixed-size footer entries (21 bytes each):**
+//!   `slope(8) + intercept(8) + bit_width(1) + data_offset(4)`
+//!
+//! The fixed entry size enables O(1) block lookup by index, which in turn allows:
+//!
+//! - **Lazy `load()`** — the footer is kept as a `FileSlice` and never eagerly
+//!   read. Block metadata is parsed on demand (21 bytes) only for accessed blocks,
+//!   giving near-zero load cost for TopK queries that touch few rows.
+//!
+//! - **Block-aware `get_row_ids_for_value_range`** — reads the footer range for
+//!   the needed blocks in one `read_bytes()` call, then one `read_bytes()` per
+//!   block. Replaces the default per-row `get_val` loop for filtered range scans.
+//!
+//! - **Single-entry `UnsafeCell` block cache in `get_val`** — sequential doc-ID
+//!   access hits the cache ~512 times per block, reducing `read_bytes` calls from
+//!   O(N) to O(N/512). Requires single-threaded access (safe in ParadeDB's
+//!   per-backend model, not suitable for upstream tantivy as-is).
+//!
+//! The footer is roughly 2–4× larger per block than V1 (~42 KB for 1M rows vs
+//! ~12–18 KB), but this is negligible relative to the data region.
+
 use std::cell::UnsafeCell;
 use std::io;
 use std::io::Write;

--- a/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
@@ -1,3 +1,4 @@
+use std::cell::UnsafeCell;
 use std::io;
 use std::io::Write;
 use std::ops::{Range, RangeInclusive};
@@ -166,25 +167,54 @@ impl ColumnCodec<u64> for BlockwiseLinearV2Codec {
             footer,
             data,
             stats,
+            cache: BlockCache::new(),
         })
+    }
+}
+
+struct CachedBlock {
+    block_id: u32,
+    line: Line,
+    bit_unpacker: BitUnpacker,
+    data: OwnedBytes,
+}
+
+struct BlockCache(UnsafeCell<CachedBlock>);
+unsafe impl Send for BlockCache {}
+unsafe impl Sync for BlockCache {}
+
+impl Clone for BlockCache {
+    fn clone(&self) -> Self {
+        BlockCache::new()
+    }
+}
+
+impl BlockCache {
+    fn new() -> Self {
+        BlockCache(UnsafeCell::new(CachedBlock {
+            block_id: u32::MAX,
+            line: Line { slope: 0, intercept: 0 },
+            bit_unpacker: BitUnpacker::new(0),
+            data: OwnedBytes::empty(),
+        }))
     }
 }
 
 #[derive(Clone)]
 pub struct BlockwiseLinearV2Reader {
-    /// Block metadata footer, kept as FileSlice for lazy access.
     footer: FileSlice,
     data: FileSlice,
     stats: ColumnStats,
+    cache: BlockCache,
 }
 
 impl BlockwiseLinearV2Reader {
-    /// Reconstructs a reader from pre-cached parts, bypassing `load()`.
     pub fn from_parts(footer: FileSlice, data: FileSlice, stats: ColumnStats) -> Self {
         Self {
             footer,
             data,
             stats,
+            cache: BlockCache::new(),
         }
     }
 
@@ -213,19 +243,25 @@ impl BlockwiseLinearV2Reader {
 impl ColumnValues for BlockwiseLinearV2Reader {
     #[inline(always)]
     fn get_val(&self, idx: u32) -> u64 {
-        let block_id = (idx / BLOCK_SIZE) as usize;
+        let block_id = idx / BLOCK_SIZE;
         let idx_within_block = idx % BLOCK_SIZE;
-        let (line, bit_width, data_start) = self.block_meta(block_id);
-        let interpoled_val: u64 = line.eval(idx_within_block);
-        let data_len = (bit_width as usize) * BLOCK_SIZE as usize / 8;
-        let data_end = (data_start + data_len).min(self.data.len());
-        let data = self
-            .data
-            .slice(data_start..data_end)
-            .read_bytes()
-            .expect("failed to read block data");
-        let bit_unpacker = BitUnpacker::new(bit_width);
-        let bitpacked_diff = bit_unpacker.get(idx_within_block, &data);
+        // SAFETY: single-threaded access per Postgres backend / per segment in tantivy.
+        let cache = unsafe { &mut *self.cache.0.get() };
+        if cache.block_id != block_id {
+            let (line, bit_width, data_start) = self.block_meta(block_id as usize);
+            let data_len = (bit_width as usize) * BLOCK_SIZE as usize / 8;
+            let data_end = (data_start + data_len).min(self.data.len());
+            cache.block_id = block_id;
+            cache.line = line;
+            cache.bit_unpacker = BitUnpacker::new(bit_width);
+            cache.data = self
+                .data
+                .slice(data_start..data_end)
+                .read_bytes()
+                .expect("failed to read block data");
+        }
+        let interpoled_val: u64 = cache.line.eval(idx_within_block);
+        let bitpacked_diff = cache.bit_unpacker.get(idx_within_block, &cache.data);
         self.stats.min_value
             + self
                 .stats

--- a/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
@@ -193,7 +193,10 @@ impl BlockCache {
     fn new() -> Self {
         BlockCache(UnsafeCell::new(CachedBlock {
             block_id: u32::MAX,
-            line: Line { slope: 0, intercept: 0 },
+            line: Line {
+                slope: 0,
+                intercept: 0,
+            },
             bit_unpacker: BitUnpacker::new(0),
             data: OwnedBytes::empty(),
         }))
@@ -288,10 +291,19 @@ impl ColumnValues for BlockwiseLinearV2Reader {
         for block_id in first_block..=last_block {
             // Parse block metadata from the pre-read footer bytes.
             let local_off = (block_id - first_block) * BLOCK_META_SIZE;
-            let slope = u64::from_le_bytes(footer_bytes[local_off..local_off + 8].try_into().unwrap());
-            let intercept = u64::from_le_bytes(footer_bytes[local_off + 8..local_off + 16].try_into().unwrap());
+            let slope =
+                u64::from_le_bytes(footer_bytes[local_off..local_off + 8].try_into().unwrap());
+            let intercept = u64::from_le_bytes(
+                footer_bytes[local_off + 8..local_off + 16]
+                    .try_into()
+                    .unwrap(),
+            );
             let bit_width = footer_bytes[local_off + 16];
-            let data_start = u32::from_le_bytes(footer_bytes[local_off + 17..local_off + 21].try_into().unwrap()) as usize;
+            let data_start = u32::from_le_bytes(
+                footer_bytes[local_off + 17..local_off + 21]
+                    .try_into()
+                    .unwrap(),
+            ) as usize;
             let line = Line { slope, intercept };
 
             let data_len = (bit_width as usize) * BLOCK_SIZE as usize / 8;

--- a/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
@@ -94,7 +94,6 @@ impl FixedSize for BlockMeta {
     const SIZE_IN_BYTES: usize = BLOCK_META_SIZE;
 }
 
-/// Parse a block metadata entry from a byte slice.
 #[inline(always)]
 fn parse_block_meta(mut entry: &[u8]) -> BlockMeta {
     BlockMeta::deserialize(&mut entry).expect("failed to parse block meta")

--- a/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
@@ -31,7 +31,7 @@ use std::io::Write;
 use std::ops::{Range, RangeInclusive};
 
 use common::file_slice::FileSlice;
-use common::{BinarySerializable, CountingWriter, DeserializeFrom, HasLen, OwnedBytes};
+use common::{BinarySerializable, CountingWriter, DeserializeFrom, FixedSize, HasLen, OwnedBytes};
 use fastdivide::DividerU64;
 use tantivy_bitpacker::{BitPacker, BitUnpacker, compute_num_bits};
 
@@ -43,16 +43,50 @@ use crate::column_values::{ColumnValues, VecColumn};
 const BLOCK_SIZE: u32 = 512u32;
 
 /// Fixed-size footer entry: slope(8) + intercept(8) + bit_width(1) + data_offset(4) = 21 bytes.
-const BLOCK_META_SIZE: usize = 21;
+#[derive(Debug, Clone, Copy)]
+struct BlockMeta {
+    line: Line,
+    bit_width: u8,
+    data_offset: u32,
+}
 
-/// Parse a 21-byte block metadata entry into (line, bit_width, data_start_offset).
+const BLOCK_META_SIZE: usize =
+    <u64 as FixedSize>::SIZE_IN_BYTES  // slope
+    + <u64 as FixedSize>::SIZE_IN_BYTES  // intercept
+    + <u8 as FixedSize>::SIZE_IN_BYTES   // bit_width
+    + <u32 as FixedSize>::SIZE_IN_BYTES; // data_offset
+
+impl BinarySerializable for BlockMeta {
+    fn serialize<W: Write + ?Sized>(&self, writer: &mut W) -> io::Result<()> {
+        self.line.slope.serialize(writer)?;
+        self.line.intercept.serialize(writer)?;
+        self.bit_width.serialize(writer)?;
+        self.data_offset.serialize(writer)?;
+        Ok(())
+    }
+
+    fn deserialize<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        let slope = u64::deserialize(reader)?;
+        let intercept = u64::deserialize(reader)?;
+        let bit_width = u8::deserialize(reader)?;
+        let data_offset = u32::deserialize(reader)?;
+        Ok(BlockMeta {
+            line: Line { slope, intercept },
+            bit_width,
+            data_offset,
+        })
+    }
+}
+
+impl FixedSize for BlockMeta {
+    const SIZE_IN_BYTES: usize = BLOCK_META_SIZE;
+}
+
+/// Parse a block metadata entry from a byte slice.
 #[inline(always)]
-fn parse_block_meta(entry: &[u8]) -> (Line, u8, usize) {
-    let slope = u64::from_le_bytes(entry[0..8].try_into().unwrap());
-    let intercept = u64::from_le_bytes(entry[8..16].try_into().unwrap());
-    let bit_width = entry[16];
-    let data_start = u32::from_le_bytes(entry[17..21].try_into().unwrap()) as usize;
-    (Line { slope, intercept }, bit_width, data_start)
+fn parse_block_meta(entry: &[u8]) -> BlockMeta {
+    let mut cursor = entry;
+    BlockMeta::deserialize(&mut cursor).expect("failed to parse block meta")
 }
 
 fn compute_num_blocks(num_vals: u32) -> u32 {
@@ -168,14 +202,11 @@ impl ColumnCodecEstimator for BlockwiseLinearV2Estimator {
 
         assert_eq!(blocks.len(), num_blocks);
 
-        // Write fixed-size footer: [slope_le64 | intercept_le64 | bit_width_u8 | data_offset_le32]
+        // Write fixed-size footer.
         let mut counting_wrt = CountingWriter::wrap(wrt);
         let mut data_offset = 0u32;
         for &(line, bit_width) in &blocks {
-            counting_wrt.write_all(&line.slope.to_le_bytes())?;
-            counting_wrt.write_all(&line.intercept.to_le_bytes())?;
-            counting_wrt.write_all(&[bit_width])?;
-            counting_wrt.write_all(&data_offset.to_le_bytes())?;
+            BlockMeta { line, bit_width, data_offset }.serialize(&mut counting_wrt)?;
             data_offset += (bit_width as u32) * BLOCK_SIZE / 8;
         }
         let footer_len = counting_wrt.written_bytes();
@@ -251,7 +282,7 @@ pub struct BlockwiseLinearV2Reader {
 
 impl BlockwiseLinearV2Reader {
     #[inline(always)]
-    fn block_meta(&self, block_id: usize) -> (Line, u8, usize) {
+    fn block_meta(&self, block_id: usize) -> BlockMeta {
         let off = block_id * BLOCK_META_SIZE;
         let entry = self
             .footer
@@ -270,12 +301,13 @@ impl ColumnValues for BlockwiseLinearV2Reader {
         // SAFETY: single-threaded access per Postgres backend / per segment in tantivy.
         let cache = unsafe { &mut *self.cache.0.get() };
         if cache.block_id != block_id {
-            let (line, bit_width, data_start) = self.block_meta(block_id as usize);
-            let data_len = (bit_width as usize) * BLOCK_SIZE as usize / 8;
+            let meta = self.block_meta(block_id as usize);
+            let data_start = meta.data_offset as usize;
+            let data_len = (meta.bit_width as usize) * BLOCK_SIZE as usize / 8;
             let data_end = (data_start + data_len).min(self.data.len());
             cache.block_id = block_id;
-            cache.line = line;
-            cache.bit_unpacker = BitUnpacker::new(bit_width);
+            cache.line = meta.line;
+            cache.bit_unpacker = BitUnpacker::new(meta.bit_width);
             cache.data = self
                 .data
                 .slice(data_start..data_end)
@@ -324,17 +356,17 @@ impl ColumnValues for BlockwiseLinearV2Reader {
         for block_id in first_block..=last_block {
             // Parse block metadata from the pre-read footer bytes.
             let local_off = (block_id - first_block) * BLOCK_META_SIZE;
-            let (line, bit_width, data_start) =
-                parse_block_meta(&footer_bytes[local_off..local_off + BLOCK_META_SIZE]);
+            let meta = parse_block_meta(&footer_bytes[local_off..local_off + BLOCK_META_SIZE]);
 
-            let data_len = (bit_width as usize) * BLOCK_SIZE as usize / 8;
+            let data_start = meta.data_offset as usize;
+            let data_len = (meta.bit_width as usize) * BLOCK_SIZE as usize / 8;
             let data_end = (data_start + data_len).min(self.data.len());
             let data = self
                 .data
                 .slice(data_start..data_end)
                 .read_bytes()
                 .expect("failed to read block data");
-            let bit_unpacker = BitUnpacker::new(bit_width);
+            let bit_unpacker = BitUnpacker::new(meta.bit_width);
 
             let block_start_row = block_id as u32 * BLOCK_SIZE;
             let local_start = if block_start_row < row_id_range.start {
@@ -345,7 +377,7 @@ impl ColumnValues for BlockwiseLinearV2Reader {
             let local_end = (row_id_range.end - block_start_row).min(BLOCK_SIZE);
 
             for idx_within_block in local_start..local_end {
-                let interpoled_val = line.eval(idx_within_block);
+                let interpoled_val = meta.line.eval(idx_within_block);
                 let bitpacked_diff = bit_unpacker.get(idx_within_block, &data);
                 let val = min_value + gcd.wrapping_mul(interpoled_val.wrapping_add(bitpacked_diff));
                 if value_range.contains(&val) {

--- a/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
@@ -18,6 +18,16 @@ const BLOCK_SIZE: u32 = 512u32;
 /// Fixed-size footer entry: slope(8) + intercept(8) + bit_width(1) + data_offset(4) = 21 bytes.
 const BLOCK_META_SIZE: usize = 21;
 
+/// Parse a 21-byte block metadata entry into (line, bit_width, data_start_offset).
+#[inline(always)]
+fn parse_block_meta(entry: &[u8]) -> (Line, u8, usize) {
+    let slope = u64::from_le_bytes(entry[0..8].try_into().unwrap());
+    let intercept = u64::from_le_bytes(entry[8..16].try_into().unwrap());
+    let bit_width = entry[16];
+    let data_start = u32::from_le_bytes(entry[17..21].try_into().unwrap()) as usize;
+    (Line { slope, intercept }, bit_width, data_start)
+}
+
 fn compute_num_blocks(num_vals: u32) -> u32 {
     num_vals.div_ceil(BLOCK_SIZE)
 }
@@ -220,12 +230,7 @@ impl BlockwiseLinearV2Reader {
             .slice(off..off + BLOCK_META_SIZE)
             .read_bytes()
             .expect("failed to read block meta");
-        let slope = u64::from_le_bytes(entry[0..8].try_into().unwrap());
-        let intercept = u64::from_le_bytes(entry[8..16].try_into().unwrap());
-        let bit_width = entry[16];
-        let data_start = u32::from_le_bytes(entry[17..21].try_into().unwrap()) as usize;
-
-        (Line { slope, intercept }, bit_width, data_start)
+        parse_block_meta(&entry)
     }
 }
 
@@ -291,20 +296,8 @@ impl ColumnValues for BlockwiseLinearV2Reader {
         for block_id in first_block..=last_block {
             // Parse block metadata from the pre-read footer bytes.
             let local_off = (block_id - first_block) * BLOCK_META_SIZE;
-            let slope =
-                u64::from_le_bytes(footer_bytes[local_off..local_off + 8].try_into().unwrap());
-            let intercept = u64::from_le_bytes(
-                footer_bytes[local_off + 8..local_off + 16]
-                    .try_into()
-                    .unwrap(),
-            );
-            let bit_width = footer_bytes[local_off + 16];
-            let data_start = u32::from_le_bytes(
-                footer_bytes[local_off + 17..local_off + 21]
-                    .try_into()
-                    .unwrap(),
-            ) as usize;
-            let line = Line { slope, intercept };
+            let (line, bit_width, data_start) =
+                parse_block_meta(&footer_bytes[local_off..local_off + BLOCK_META_SIZE]);
 
             let data_len = (bit_width as usize) * BLOCK_SIZE as usize / 8;
             let data_end = (data_start + data_len).min(self.data.len());

--- a/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
@@ -9,17 +9,16 @@
 //!
 //! The fixed entry size enables O(1) block lookup by index, which in turn allows:
 //!
-//! - **Lazy `load()`** — the footer is kept as a `FileSlice` and never eagerly
-//!   read. Block metadata is parsed on demand (21 bytes) only for accessed blocks,
-//!   giving near-zero load cost for TopK queries that touch few rows.
+//! - **Lazy `load()`** — the footer is kept as a `FileSlice` and never eagerly read. Block metadata
+//!   is parsed on demand (21 bytes) only for accessed blocks, giving near-zero load cost for TopK
+//!   queries that touch few rows.
 //!
-//! - **Block-aware `get_row_ids_for_value_range`** — reads the footer range for
-//!   the needed blocks in one `read_bytes()` call, then one `read_bytes()` per
-//!   block. Replaces the default per-row `get_val` loop for filtered range scans.
+//! - **Block-aware `get_row_ids_for_value_range`** — reads the footer range for the needed blocks
+//!   in one `read_bytes()` call, then one `read_bytes()` per block. Replaces the default per-row
+//!   `get_val` loop for filtered range scans.
 //!
-//! - **Single-entry block cache in `get_val`** — sequential doc-ID access hits
-//!   the cache ~512 times per block, reducing `read_bytes` calls from O(N) to
-//!   O(N/512).
+//! - **Single-entry block cache in `get_val`** — sequential doc-ID access hits the cache ~512 times
+//!   per block, reducing `read_bytes` calls from O(N) to O(N/512).
 //!
 //! The footer is roughly 2–4× larger per block than V1 (~42 KB for 1M rows vs
 //! ~12–18 KB), but this is negligible relative to the data region.
@@ -52,8 +51,7 @@ struct BlockMeta {
     data_offset: u32,
 }
 
-const BLOCK_META_SIZE: usize =
-    <u64 as FixedSize>::SIZE_IN_BYTES  // slope
+const BLOCK_META_SIZE: usize = <u64 as FixedSize>::SIZE_IN_BYTES  // slope
     + <u64 as FixedSize>::SIZE_IN_BYTES  // intercept
     + <u8 as FixedSize>::SIZE_IN_BYTES   // bit_width
     + <u32 as FixedSize>::SIZE_IN_BYTES; // data_offset
@@ -208,7 +206,12 @@ impl ColumnCodecEstimator for BlockwiseLinearV2Estimator {
         let mut counting_wrt = CountingWriter::wrap(wrt);
         let mut data_offset = 0u32;
         for &(line, bit_width) in &blocks {
-            BlockMeta { line, bit_width, data_offset }.serialize(&mut counting_wrt)?;
+            BlockMeta {
+                line,
+                bit_width,
+                data_offset,
+            }
+            .serialize(&mut counting_wrt)?;
             data_offset += bit_width as u32;
         }
         let footer_len = counting_wrt.written_bytes();

--- a/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
@@ -41,12 +41,16 @@ use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnS
 use crate::column_values::{ColumnValues, VecColumn};
 
 const BLOCK_SIZE: u32 = 512u32;
+const DATA_OFFSET_UNIT: usize = (BLOCK_SIZE / 8) as usize; // 64 bytes
 
 /// Fixed-size footer entry: slope(8) + intercept(8) + bit_width(1) + data_offset(4) = 21 bytes.
+/// `data_offset` is stored in units of 64 bytes (BLOCK_SIZE / 8), not raw bytes,
+/// extending the addressable range from ~4GB to ~256GB per column per segment.
 #[derive(Debug, Clone, Copy)]
 struct BlockMeta {
     line: Line,
     bit_width: u8,
+    /// Offset into the data region in units of 64 bytes.
     data_offset: u32,
 }
 
@@ -207,7 +211,7 @@ impl ColumnCodecEstimator for BlockwiseLinearV2Estimator {
         let mut data_offset = 0u32;
         for &(line, bit_width) in &blocks {
             BlockMeta { line, bit_width, data_offset }.serialize(&mut counting_wrt)?;
-            data_offset += (bit_width as u32) * BLOCK_SIZE / 8;
+            data_offset += bit_width as u32;
         }
         let footer_len = counting_wrt.written_bytes();
         (footer_len as u32).serialize(&mut counting_wrt)?;
@@ -302,8 +306,8 @@ impl ColumnValues for BlockwiseLinearV2Reader {
         let cache = unsafe { &mut *self.cache.0.get() };
         if cache.block_id != block_id {
             let meta = self.block_meta(block_id as usize);
-            let data_start = meta.data_offset as usize;
-            let data_len = (meta.bit_width as usize) * BLOCK_SIZE as usize / 8;
+            let data_start = meta.data_offset as usize * DATA_OFFSET_UNIT;
+            let data_len = meta.bit_width as usize * DATA_OFFSET_UNIT;
             let data_end = (data_start + data_len).min(self.data.len());
             cache.block_id = block_id;
             cache.line = meta.line;
@@ -358,8 +362,8 @@ impl ColumnValues for BlockwiseLinearV2Reader {
             let local_off = (block_id - first_block) * BLOCK_META_SIZE;
             let meta = parse_block_meta(&footer_bytes[local_off..local_off + BLOCK_META_SIZE]);
 
-            let data_start = meta.data_offset as usize;
-            let data_len = (meta.bit_width as usize) * BLOCK_SIZE as usize / 8;
+            let data_start = meta.data_offset as usize * DATA_OFFSET_UNIT;
+            let data_len = meta.bit_width as usize * DATA_OFFSET_UNIT;
             let data_end = (data_start + data_len).min(self.data.len());
             let data = self
                 .data

--- a/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
@@ -1,0 +1,363 @@
+use std::io;
+use std::io::Write;
+use std::ops::{Range, RangeInclusive};
+
+use common::file_slice::FileSlice;
+use common::{BinarySerializable, CountingWriter, DeserializeFrom, HasLen, OwnedBytes};
+use fastdivide::DividerU64;
+use tantivy_bitpacker::{BitPacker, BitUnpacker, compute_num_bits};
+
+use crate::MonotonicallyMappableToU64;
+use crate::column_values::u64_based::line::Line;
+use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnStats};
+use crate::column_values::{ColumnValues, VecColumn};
+
+const BLOCK_SIZE: u32 = 512u32;
+
+/// Fixed-size footer entry: slope(8) + intercept(8) + bit_width(1) + data_offset(4) = 21 bytes.
+const BLOCK_META_SIZE: usize = 21;
+
+fn compute_num_blocks(num_vals: u32) -> u32 {
+    num_vals.div_ceil(BLOCK_SIZE)
+}
+
+pub struct BlockwiseLinearV2Estimator {
+    block: Vec<u64>,
+    values_num_bytes: u64,
+    num_blocks: u64,
+}
+
+impl Default for BlockwiseLinearV2Estimator {
+    fn default() -> Self {
+        Self {
+            block: Vec::with_capacity(BLOCK_SIZE as usize),
+            values_num_bytes: 0u64,
+            num_blocks: 0u64,
+        }
+    }
+}
+
+impl BlockwiseLinearV2Estimator {
+    fn flush_block_estimate(&mut self) {
+        if self.block.is_empty() {
+            return;
+        }
+        let column = VecColumn::from(std::mem::take(&mut self.block));
+        let line = Line::train(&column);
+        self.block = column.into();
+
+        let mut max_value = 0u64;
+        for (i, buffer_val) in self.block.iter().enumerate() {
+            let interpolated_val = line.eval(i as u32);
+            let val = buffer_val.wrapping_sub(interpolated_val);
+            max_value = val.max(max_value);
+        }
+        let bit_width = compute_num_bits(max_value) as usize;
+        self.values_num_bytes += (bit_width * self.block.len() + 7) as u64 / 8;
+        self.num_blocks += 1;
+    }
+}
+
+impl ColumnCodecEstimator for BlockwiseLinearV2Estimator {
+    fn collect(&mut self, value: u64) {
+        self.block.push(value);
+        if self.block.len() == BLOCK_SIZE as usize {
+            self.flush_block_estimate();
+            self.block.clear();
+        }
+    }
+
+    fn estimate(&self, stats: &ColumnStats) -> Option<u64> {
+        let meta_num_bytes = self.num_blocks * BLOCK_META_SIZE as u64;
+        let mut estimate = 4 + stats.num_bytes() + meta_num_bytes + self.values_num_bytes;
+        if stats.gcd.get() > 1 {
+            let estimate_gain_from_gcd =
+                (stats.gcd.get() as f32).log2().floor() * stats.num_rows as f32 / 8.0f32;
+            estimate = estimate.saturating_sub(estimate_gain_from_gcd as u64);
+        }
+        Some(estimate)
+    }
+
+    fn finalize(&mut self) {
+        self.flush_block_estimate();
+    }
+
+    fn serialize(
+        &self,
+        stats: &ColumnStats,
+        mut vals: &mut dyn Iterator<Item = u64>,
+        wrt: &mut dyn Write,
+    ) -> io::Result<()> {
+        stats.serialize(wrt)?;
+        let mut buffer = Vec::with_capacity(BLOCK_SIZE as usize);
+        let num_blocks = compute_num_blocks(stats.num_rows) as usize;
+        let mut blocks: Vec<(Line, u8)> = Vec::with_capacity(num_blocks);
+
+        let mut bit_packer = BitPacker::new();
+        let gcd_divider = DividerU64::divide_by(stats.gcd.get());
+
+        for _ in 0..num_blocks {
+            buffer.clear();
+            buffer.extend(
+                (&mut vals)
+                    .map(MonotonicallyMappableToU64::to_u64)
+                    .take(BLOCK_SIZE as usize),
+            );
+
+            for buffer_val in buffer.iter_mut() {
+                *buffer_val = gcd_divider.divide(*buffer_val - stats.min_value);
+            }
+
+            let line = Line::train(&VecColumn::from(buffer.to_vec()));
+
+            assert!(!buffer.is_empty());
+
+            for (i, buffer_val) in buffer.iter_mut().enumerate() {
+                let interpolated_val = line.eval(i as u32);
+                *buffer_val = buffer_val.wrapping_sub(interpolated_val);
+            }
+
+            let bit_width = buffer.iter().copied().map(compute_num_bits).max().unwrap();
+
+            for &buffer_val in &buffer {
+                bit_packer.write(buffer_val, bit_width, wrt)?;
+            }
+
+            blocks.push((line, bit_width));
+        }
+
+        bit_packer.close(wrt)?;
+
+        assert_eq!(blocks.len(), num_blocks);
+
+        // Write fixed-size footer: [slope_le64 | intercept_le64 | bit_width_u8 | data_offset_le32]
+        let mut counting_wrt = CountingWriter::wrap(wrt);
+        let mut data_offset = 0u32;
+        for &(line, bit_width) in &blocks {
+            counting_wrt.write_all(&line.slope.to_le_bytes())?;
+            counting_wrt.write_all(&line.intercept.to_le_bytes())?;
+            counting_wrt.write_all(&[bit_width])?;
+            counting_wrt.write_all(&data_offset.to_le_bytes())?;
+            data_offset += (bit_width as u32) * BLOCK_SIZE / 8;
+        }
+        let footer_len = counting_wrt.written_bytes();
+        (footer_len as u32).serialize(&mut counting_wrt)?;
+
+        Ok(())
+    }
+}
+
+pub struct BlockwiseLinearV2Codec;
+
+impl ColumnCodec<u64> for BlockwiseLinearV2Codec {
+    type ColumnValues = BlockwiseLinearV2Reader;
+    type Estimator = BlockwiseLinearV2Estimator;
+
+    fn load(file_slice: FileSlice) -> io::Result<Self::ColumnValues> {
+        let (stats, body) = ColumnStats::deserialize_from_tail(file_slice)?;
+
+        let (_, footer_len_slice) = body.clone().split_from_end(4);
+        let footer_len: u32 = footer_len_slice.read_bytes()?.as_slice().deserialize()?;
+        let (data, footer) = body.split_from_end(footer_len as usize + 4);
+        // footer is kept as FileSlice — NOT eagerly read into OwnedBytes.
+        // Individual block metadata is read on demand (21 bytes per block).
+
+        Ok(BlockwiseLinearV2Reader {
+            footer,
+            data,
+            stats,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct BlockwiseLinearV2Reader {
+    /// Block metadata footer, kept as FileSlice for lazy access.
+    footer: FileSlice,
+    data: FileSlice,
+    stats: ColumnStats,
+}
+
+impl BlockwiseLinearV2Reader {
+    /// Reconstructs a reader from pre-cached parts, bypassing `load()`.
+    pub fn from_parts(footer: FileSlice, data: FileSlice, stats: ColumnStats) -> Self {
+        Self {
+            footer,
+            data,
+            stats,
+        }
+    }
+
+    /// Extracts the reader's parts for external caching.
+    pub fn into_parts(self) -> (FileSlice, FileSlice, ColumnStats) {
+        (self.footer, self.data, self.stats)
+    }
+
+    #[inline(always)]
+    fn block_meta(&self, block_id: usize) -> (Line, u8, usize) {
+        let off = block_id * BLOCK_META_SIZE;
+        let entry = self
+            .footer
+            .slice(off..off + BLOCK_META_SIZE)
+            .read_bytes()
+            .expect("failed to read block meta");
+        let slope = u64::from_le_bytes(entry[0..8].try_into().unwrap());
+        let intercept = u64::from_le_bytes(entry[8..16].try_into().unwrap());
+        let bit_width = entry[16];
+        let data_start = u32::from_le_bytes(entry[17..21].try_into().unwrap()) as usize;
+
+        (Line { slope, intercept }, bit_width, data_start)
+    }
+}
+
+impl ColumnValues for BlockwiseLinearV2Reader {
+    #[inline(always)]
+    fn get_val(&self, idx: u32) -> u64 {
+        let block_id = (idx / BLOCK_SIZE) as usize;
+        let idx_within_block = idx % BLOCK_SIZE;
+        let (line, bit_width, data_start) = self.block_meta(block_id);
+        let interpoled_val: u64 = line.eval(idx_within_block);
+        let data_len = (bit_width as usize) * BLOCK_SIZE as usize / 8;
+        let data_end = (data_start + data_len).min(self.data.len());
+        let data = self
+            .data
+            .slice(data_start..data_end)
+            .read_bytes()
+            .expect("failed to read block data");
+        let bit_unpacker = BitUnpacker::new(bit_width);
+        let bitpacked_diff = bit_unpacker.get(idx_within_block, &data);
+        self.stats.min_value
+            + self
+                .stats
+                .gcd
+                .get()
+                .wrapping_mul(interpoled_val.wrapping_add(bitpacked_diff))
+    }
+
+    fn get_row_ids_for_value_range(
+        &self,
+        value_range: RangeInclusive<u64>,
+        row_id_range: Range<u32>,
+        row_id_hits: &mut Vec<u32>,
+    ) {
+        if value_range.is_empty() {
+            return;
+        }
+        let row_id_range = row_id_range.start..row_id_range.end.min(self.stats.num_rows);
+        if row_id_range.is_empty() {
+            return;
+        }
+
+        let min_value = self.stats.min_value;
+        let gcd = self.stats.gcd.get();
+
+        let first_block = (row_id_range.start / BLOCK_SIZE) as usize;
+        let last_block = ((row_id_range.end - 1) / BLOCK_SIZE) as usize;
+
+        // Read footer once for the block range — avoids per-block read_bytes on footer.
+        let footer_start = first_block * BLOCK_META_SIZE;
+        let footer_end = (last_block + 1) * BLOCK_META_SIZE;
+        let footer_bytes = self
+            .footer
+            .slice(footer_start..footer_end.min(self.footer.len()))
+            .read_bytes()
+            .expect("failed to read footer range");
+
+        for block_id in first_block..=last_block {
+            // Parse block metadata from the pre-read footer bytes.
+            let local_off = (block_id - first_block) * BLOCK_META_SIZE;
+            let slope = u64::from_le_bytes(footer_bytes[local_off..local_off + 8].try_into().unwrap());
+            let intercept = u64::from_le_bytes(footer_bytes[local_off + 8..local_off + 16].try_into().unwrap());
+            let bit_width = footer_bytes[local_off + 16];
+            let data_start = u32::from_le_bytes(footer_bytes[local_off + 17..local_off + 21].try_into().unwrap()) as usize;
+            let line = Line { slope, intercept };
+
+            let data_len = (bit_width as usize) * BLOCK_SIZE as usize / 8;
+            let data_end = (data_start + data_len).min(self.data.len());
+            let data = self
+                .data
+                .slice(data_start..data_end)
+                .read_bytes()
+                .expect("failed to read block data");
+            let bit_unpacker = BitUnpacker::new(bit_width);
+
+            let block_start_row = block_id as u32 * BLOCK_SIZE;
+            let local_start = if block_start_row < row_id_range.start {
+                row_id_range.start - block_start_row
+            } else {
+                0
+            };
+            let local_end = (row_id_range.end - block_start_row).min(BLOCK_SIZE);
+
+            for idx_within_block in local_start..local_end {
+                let interpoled_val = line.eval(idx_within_block);
+                let bitpacked_diff = bit_unpacker.get(idx_within_block, &data);
+                let val = min_value + gcd.wrapping_mul(interpoled_val.wrapping_add(bitpacked_diff));
+                if value_range.contains(&val) {
+                    row_id_hits.push(block_start_row + idx_within_block);
+                }
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn min_value(&self) -> u64 {
+        self.stats.min_value
+    }
+
+    #[inline(always)]
+    fn max_value(&self) -> u64 {
+        self.stats.max_value
+    }
+
+    #[inline(always)]
+    fn num_vals(&self) -> u32 {
+        self.stats.num_rows
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::column_values::u64_based::tests::create_and_validate;
+
+    #[test]
+    fn test_v2_simple() {
+        create_and_validate::<BlockwiseLinearV2Codec>(
+            &[11, 20, 40, 20, 10, 10, 10, 10, 10, 10],
+            "simple test",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_v2_gcd() {
+        create_and_validate::<BlockwiseLinearV2Codec>(
+            &[10, 20, 40, 20, 10, 10, 10, 10, 10, 10],
+            "name",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_v2_datasets() {
+        let data_sets = crate::column_values::u64_based::tests::get_codec_test_datasets();
+        for (mut data, name) in data_sets {
+            create_and_validate::<BlockwiseLinearV2Codec>(&data, name);
+            data.reverse();
+            create_and_validate::<BlockwiseLinearV2Codec>(&data, name);
+        }
+    }
+
+    #[test]
+    fn test_v2_rand() {
+        for _ in 0..500 {
+            let mut data = (0..1 + rand::random::<u8>() as usize)
+                .map(|_| rand::random::<i64>() as u64 / 2)
+                .collect::<Vec<_>>();
+            create_and_validate::<BlockwiseLinearV2Codec>(&data, "rand");
+            data.reverse();
+            create_and_validate::<BlockwiseLinearV2Codec>(&data, "rand");
+        }
+    }
+}

--- a/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
@@ -209,20 +209,6 @@ pub struct BlockwiseLinearV2Reader {
 }
 
 impl BlockwiseLinearV2Reader {
-    pub fn from_parts(footer: FileSlice, data: FileSlice, stats: ColumnStats) -> Self {
-        Self {
-            footer,
-            data,
-            stats,
-            cache: BlockCache::new(),
-        }
-    }
-
-    /// Extracts the reader's parts for external caching.
-    pub fn into_parts(self) -> (FileSlice, FileSlice, ColumnStats) {
-        (self.footer, self.data, self.stats)
-    }
-
     #[inline(always)]
     fn block_meta(&self, block_id: usize) -> (Line, u8, usize) {
         let off = block_id * BLOCK_META_SIZE;

--- a/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
@@ -217,6 +217,7 @@ struct CachedBlock {
 }
 
 struct BlockCache(UnsafeCell<CachedBlock>);
+// SAFETY: single-threaded access per Postgres backend / per segment in tantivy.
 unsafe impl Send for BlockCache {}
 unsafe impl Sync for BlockCache {}
 

--- a/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear_v2.rs
@@ -17,15 +17,13 @@
 //!   the needed blocks in one `read_bytes()` call, then one `read_bytes()` per
 //!   block. Replaces the default per-row `get_val` loop for filtered range scans.
 //!
-//! - **Single-entry `UnsafeCell` block cache in `get_val`** — sequential doc-ID
-//!   access hits the cache ~512 times per block, reducing `read_bytes` calls from
-//!   O(N) to O(N/512). Requires single-threaded access (safe in ParadeDB's
-//!   per-backend model, not suitable for upstream tantivy as-is).
+//! - **Single-entry block cache in `get_val`** — sequential doc-ID access hits
+//!   the cache ~512 times per block, reducing `read_bytes` calls from O(N) to
+//!   O(N/512).
 //!
 //! The footer is roughly 2–4× larger per block than V1 (~42 KB for 1M rows vs
 //! ~12–18 KB), but this is negligible relative to the data region.
 
-use std::cell::UnsafeCell;
 use std::io;
 use std::io::Write;
 use std::ops::{Range, RangeInclusive};
@@ -251,10 +249,7 @@ struct CachedBlock {
     data: OwnedBytes,
 }
 
-struct BlockCache(UnsafeCell<CachedBlock>);
-// SAFETY: single-threaded access per Postgres backend / per segment in tantivy.
-unsafe impl Send for BlockCache {}
-unsafe impl Sync for BlockCache {}
+struct BlockCache(parking_lot::Mutex<CachedBlock>);
 
 impl Clone for BlockCache {
     fn clone(&self) -> Self {
@@ -264,7 +259,7 @@ impl Clone for BlockCache {
 
 impl BlockCache {
     fn new() -> Self {
-        BlockCache(UnsafeCell::new(CachedBlock {
+        BlockCache(parking_lot::Mutex::new(CachedBlock {
             block_id: u32::MAX,
             line: Line {
                 slope: 0,
@@ -302,8 +297,7 @@ impl ColumnValues for BlockwiseLinearV2Reader {
     fn get_val(&self, idx: u32) -> u64 {
         let block_id = idx / BLOCK_SIZE;
         let idx_within_block = idx % BLOCK_SIZE;
-        // SAFETY: single-threaded access per Postgres backend / per segment in tantivy.
-        let cache = unsafe { &mut *self.cache.0.get() };
+        let mut cache = self.cache.0.lock();
         if cache.block_id != block_id {
             let meta = self.block_meta(block_id as usize);
             let data_start = meta.data_offset as usize * DATA_OFFSET_UNIT;

--- a/columnar/src/column_values/u64_based/mod.rs
+++ b/columnar/src/column_values/u64_based/mod.rs
@@ -77,7 +77,9 @@ pub trait ColumnCodec<T: PartialOrd = u64> {
 }
 
 /// Available codecs to use to encode the u64 (via [`MonotonicallyMappableToU64`]) converted data.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+#[derive(
+    PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy, serde::Serialize, serde::Deserialize,
+)]
 #[repr(u8)]
 pub enum CodecType {
     /// Bitpack all values in the value range. The number of bits is defined by the amplitude

--- a/columnar/src/column_values/u64_based/mod.rs
+++ b/columnar/src/column_values/u64_based/mod.rs
@@ -17,7 +17,7 @@ use crate::column_values::monotonic_mapping::{
 };
 pub use crate::column_values::u64_based::bitpacked::BitpackedCodec;
 pub use crate::column_values::u64_based::blockwise_linear::BlockwiseLinearCodec;
-pub use crate::column_values::u64_based::blockwise_linear_v2::BlockwiseLinearV2Codec;
+pub(crate) use crate::column_values::u64_based::blockwise_linear_v2::BlockwiseLinearV2Codec;
 pub use crate::column_values::u64_based::linear::LinearCodec;
 pub use crate::column_values::u64_based::stats_collector::StatsCollector;
 use crate::column_values::{ColumnStats, monotonic_map_column};

--- a/columnar/src/column_values/u64_based/mod.rs
+++ b/columnar/src/column_values/u64_based/mod.rs
@@ -1,5 +1,6 @@
 mod bitpacked;
 mod blockwise_linear;
+mod blockwise_linear_v2;
 mod line;
 mod linear;
 mod stats_collector;
@@ -16,6 +17,9 @@ use crate::column_values::monotonic_mapping::{
 };
 pub use crate::column_values::u64_based::bitpacked::BitpackedCodec;
 pub use crate::column_values::u64_based::blockwise_linear::BlockwiseLinearCodec;
+pub use crate::column_values::u64_based::blockwise_linear_v2::{
+    BlockwiseLinearV2Codec, BlockwiseLinearV2Reader,
+};
 pub use crate::column_values::u64_based::linear::LinearCodec;
 pub use crate::column_values::u64_based::stats_collector::StatsCollector;
 use crate::column_values::{ColumnStats, monotonic_map_column};
@@ -87,13 +91,16 @@ pub enum CodecType {
     Linear = 1u8,
     /// Same as [`CodecType::Linear`], but encodes in blocks of 512 elements.
     BlockwiseLinear = 2u8,
+    /// Same as [`CodecType::BlockwiseLinear`], but with a fixed-size footer for O(1) block access.
+    BlockwiseLinearV2 = 3u8,
 }
 
 /// List of all available u64-base codecs.
-pub const ALL_U64_CODEC_TYPES: [CodecType; 3] = [
+pub const ALL_U64_CODEC_TYPES: [CodecType; 4] = [
     CodecType::Bitpacked,
     CodecType::Linear,
     CodecType::BlockwiseLinear,
+    CodecType::BlockwiseLinearV2,
 ];
 
 impl CodecType {
@@ -106,6 +113,7 @@ impl CodecType {
             0u8 => Some(CodecType::Bitpacked),
             1u8 => Some(CodecType::Linear),
             2u8 => Some(CodecType::BlockwiseLinear),
+            3u8 => Some(CodecType::BlockwiseLinearV2),
             _ => None,
         }
     }
@@ -119,6 +127,9 @@ impl CodecType {
             CodecType::Linear => load_specific_codec::<LinearCodec, T>(file_slice),
             CodecType::BlockwiseLinear => {
                 load_specific_codec::<BlockwiseLinearCodec, T>(file_slice)
+            }
+            CodecType::BlockwiseLinearV2 => {
+                load_specific_codec::<BlockwiseLinearV2Codec, T>(file_slice)
             }
         }
     }
@@ -142,6 +153,7 @@ impl CodecType {
             CodecType::Bitpacked => BitpackedCodec::boxed_estimator(),
             CodecType::Linear => LinearCodec::boxed_estimator(),
             CodecType::BlockwiseLinear => BlockwiseLinearCodec::boxed_estimator(),
+            CodecType::BlockwiseLinearV2 => BlockwiseLinearV2Codec::boxed_estimator(),
         }
     }
 }

--- a/columnar/src/column_values/u64_based/mod.rs
+++ b/columnar/src/column_values/u64_based/mod.rs
@@ -17,9 +17,7 @@ use crate::column_values::monotonic_mapping::{
 };
 pub use crate::column_values::u64_based::bitpacked::BitpackedCodec;
 pub use crate::column_values::u64_based::blockwise_linear::BlockwiseLinearCodec;
-pub use crate::column_values::u64_based::blockwise_linear_v2::{
-    BlockwiseLinearV2Codec, BlockwiseLinearV2Reader,
-};
+pub use crate::column_values::u64_based::blockwise_linear_v2::BlockwiseLinearV2Codec;
 pub use crate::column_values::u64_based::linear::LinearCodec;
 pub use crate::column_values::u64_based::stats_collector::StatsCollector;
 use crate::column_values::{ColumnStats, monotonic_map_column};

--- a/columnar/src/column_values/u64_based/mod.rs
+++ b/columnar/src/column_values/u64_based/mod.rs
@@ -77,7 +77,7 @@ pub trait ColumnCodec<T: PartialOrd = u64> {
 }
 
 /// Available codecs to use to encode the u64 (via [`MonotonicallyMappableToU64`]) converted data.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 #[repr(u8)]
 pub enum CodecType {
     /// Bitpack all values in the value range. The number of bits is defined by the amplitude
@@ -102,11 +102,13 @@ pub const ALL_U64_CODEC_TYPES: [CodecType; 4] = [
 ];
 
 impl CodecType {
-    fn to_code(self) -> u8 {
+    /// Returns the u8 code for this codec type.
+    pub fn to_code(self) -> u8 {
         self as u8
     }
 
-    fn try_from_code(code: u8) -> Option<CodecType> {
+    /// Attempts to convert a u8 code to a `CodecType`. Returns `None` for unknown codes.
+    pub fn try_from_code(code: u8) -> Option<CodecType> {
         match code {
             0u8 => Some(CodecType::Bitpacked),
             1u8 => Some(CodecType::Linear),

--- a/columnar/src/column_values/u64_based/tests.rs
+++ b/columnar/src/column_values/u64_based/tests.rs
@@ -175,6 +175,11 @@ proptest! {
     fn test_proptest_small_blockwise_linear(data in proptest::collection::vec(num_strategy(), 1..10)) {
         create_and_validate::<BlockwiseLinearCodec>(&data, "proptest multilinearinterpol");
     }
+
+    #[test]
+    fn test_proptest_small_blockwise_linear_v2(data in proptest::collection::vec(num_strategy(), 1..10)) {
+        create_and_validate::<BlockwiseLinearV2Codec>(&data, "proptest multilinearinterpol v2");
+    }
 }
 
 #[test]
@@ -201,6 +206,11 @@ proptest! {
     #[test]
     fn test_proptest_large_blockwise_linear(data in proptest::collection::vec(num_strategy(), 1..6000)) {
         create_and_validate::<BlockwiseLinearCodec>(&data, "proptest multilinearinterpol");
+    }
+
+    #[test]
+    fn test_proptest_large_blockwise_linear_v2(data in proptest::collection::vec(num_strategy(), 1..6000)) {
+        create_and_validate::<BlockwiseLinearV2Codec>(&data, "proptest multilinearinterpol v2");
     }
 }
 
@@ -257,6 +267,10 @@ fn test_codec_interpolation() {
 #[test]
 fn test_codec_multi_interpolation() {
     test_codec::<BlockwiseLinearCodec>();
+}
+#[test]
+fn test_codec_multi_interpolation_v2() {
+    test_codec::<BlockwiseLinearV2Codec>();
 }
 
 use super::*;
@@ -316,7 +330,7 @@ fn test_fast_field_codec_type_to_code() {
             count_codec += 1;
         }
     }
-    assert_eq!(count_codec, 3);
+    assert_eq!(count_codec, 4);
 }
 
 fn test_fastfield_gcd_i64_with_codec(codec_type: CodecType, num_vals: usize) -> io::Result<()> {
@@ -355,6 +369,7 @@ fn test_fastfield_gcd_i64() -> io::Result<()> {
     for &codec_type in &[
         CodecType::Bitpacked,
         CodecType::BlockwiseLinear,
+        CodecType::BlockwiseLinearV2,
         CodecType::Linear,
     ] {
         test_fastfield_gcd_i64_with_codec(codec_type, 5500)?;
@@ -397,6 +412,7 @@ fn test_fastfield_gcd_u64() -> io::Result<()> {
     for &codec_type in &[
         CodecType::Bitpacked,
         CodecType::BlockwiseLinear,
+        CodecType::BlockwiseLinearV2,
         CodecType::Linear,
     ] {
         test_fastfield_gcd_u64_with_codec(codec_type, 5500)?;

--- a/columnar/src/columnar/merge/merge_dict_column.rs
+++ b/columnar/src/columnar/merge/merge_dict_column.rs
@@ -6,6 +6,7 @@ use sstable::{SSTable, Streamer, TermOrdinal, VoidSSTable};
 use super::term_merger::{TermMerger, TermsWithSegmentOrd};
 use crate::column::serialize_column_mappable_to_u64;
 use crate::column_index::SerializableColumnIndex;
+use crate::column_values::CodecType;
 use crate::iterable::Iterable;
 use crate::{BytesColumn, MergeRowOrder, ShuffleMergeOrder};
 
@@ -15,6 +16,7 @@ pub fn merge_bytes_or_str_column(
     column_index: SerializableColumnIndex<'_>,
     bytes_columns: &[Option<BytesColumn>],
     merge_row_order: &MergeRowOrder,
+    codec_types: &[CodecType],
     output: &mut impl Write,
 ) -> io::Result<()> {
     // Serialize dict and generate mapping for values
@@ -28,7 +30,7 @@ pub fn merge_bytes_or_str_column(
         term_ord_mapping: &term_ord_mapping,
         merge_row_order,
     };
-    serialize_column_mappable_to_u64(column_index, &remapped_term_ordinals_values, output)?;
+    serialize_column_mappable_to_u64(column_index, &remapped_term_ordinals_values, codec_types, output)?;
     output.write_all(&dictionary_num_bytes.to_le_bytes())?;
     Ok(())
 }

--- a/columnar/src/columnar/merge/merge_dict_column.rs
+++ b/columnar/src/columnar/merge/merge_dict_column.rs
@@ -30,7 +30,12 @@ pub fn merge_bytes_or_str_column(
         term_ord_mapping: &term_ord_mapping,
         merge_row_order,
     };
-    serialize_column_mappable_to_u64(column_index, &remapped_term_ordinals_values, codec_types, output)?;
+    serialize_column_mappable_to_u64(
+        column_index,
+        &remapped_term_ordinals_values,
+        codec_types,
+        output,
+    )?;
     output.write_all(&dictionary_num_bytes.to_le_bytes())?;
     Ok(())
 }

--- a/columnar/src/columnar/merge/mod.rs
+++ b/columnar/src/columnar/merge/mod.rs
@@ -13,8 +13,7 @@ pub use merge_mapping::{MergeRowOrder, ShuffleMergeOrder, StackMergeOrder};
 
 use super::writer::ColumnarSerializer;
 use crate::column::{serialize_column_mappable_to_u64, serialize_column_mappable_to_u128};
-use crate::column_values::CodecType;
-use crate::column_values::MergedColumnValues;
+use crate::column_values::{CodecType, MergedColumnValues};
 use crate::columnar::ColumnarReader;
 use crate::columnar::merge::merge_dict_column::merge_bytes_or_str_column;
 use crate::columnar::writer::CompatibleNumericalTypes;
@@ -174,7 +173,12 @@ fn merge_column(
                 column_values: &column_values[..],
                 merge_row_order,
             };
-            serialize_column_mappable_to_u64(merged_column_index, &merge_column_values, codec_types, wrt)?;
+            serialize_column_mappable_to_u64(
+                merged_column_index,
+                &merge_column_values,
+                codec_types,
+                wrt,
+            )?;
         }
         ColumnType::IpAddr => {
             let mut column_indexes: Vec<ColumnIndex> = Vec::with_capacity(columns_to_merge.len());
@@ -228,7 +232,13 @@ fn merge_column(
             }
             let merged_column_index =
                 crate::column_index::merge_column_index(&column_indexes[..], merge_row_order);
-            merge_bytes_or_str_column(merged_column_index, &bytes_columns, merge_row_order, codec_types, wrt)?;
+            merge_bytes_or_str_column(
+                merged_column_index,
+                &bytes_columns,
+                merge_row_order,
+                codec_types,
+                wrt,
+            )?;
         }
     }
     Ok(())

--- a/columnar/src/columnar/merge/mod.rs
+++ b/columnar/src/columnar/merge/mod.rs
@@ -13,6 +13,7 @@ pub use merge_mapping::{MergeRowOrder, ShuffleMergeOrder, StackMergeOrder};
 
 use super::writer::ColumnarSerializer;
 use crate::column::{serialize_column_mappable_to_u64, serialize_column_mappable_to_u128};
+use crate::column_values::CodecType;
 use crate::column_values::MergedColumnValues;
 use crate::columnar::ColumnarReader;
 use crate::columnar::merge::merge_dict_column::merge_bytes_or_str_column;
@@ -79,6 +80,7 @@ pub fn merge_columnar(
     columnar_readers: &[&ColumnarReader],
     required_columns: &[(String, ColumnType)],
     merge_row_order: MergeRowOrder,
+    codec_types: &[CodecType],
     output: &mut impl io::Write,
     cancel: impl Fn() -> bool,
 ) -> io::Result<()> {
@@ -113,6 +115,7 @@ pub fn merge_columnar(
             &num_docs_per_columnar,
             columns,
             &merge_row_order,
+            codec_types,
             &mut column_serializer,
         )?;
         column_serializer.finalize()?;
@@ -138,6 +141,7 @@ fn merge_column(
     num_docs_per_column: &[u32],
     columns_to_merge: Vec<Option<DynamicColumn>>,
     merge_row_order: &MergeRowOrder,
+    codec_types: &[CodecType],
     wrt: &mut impl io::Write,
 ) -> io::Result<()> {
     match column_type {
@@ -170,7 +174,7 @@ fn merge_column(
                 column_values: &column_values[..],
                 merge_row_order,
             };
-            serialize_column_mappable_to_u64(merged_column_index, &merge_column_values, wrt)?;
+            serialize_column_mappable_to_u64(merged_column_index, &merge_column_values, codec_types, wrt)?;
         }
         ColumnType::IpAddr => {
             let mut column_indexes: Vec<ColumnIndex> = Vec::with_capacity(columns_to_merge.len());
@@ -224,7 +228,7 @@ fn merge_column(
             }
             let merged_column_index =
                 crate::column_index::merge_column_index(&column_indexes[..], merge_row_order);
-            merge_bytes_or_str_column(merged_column_index, &bytes_columns, merge_row_order, wrt)?;
+            merge_bytes_or_str_column(merged_column_index, &bytes_columns, merge_row_order, codec_types, wrt)?;
         }
     }
     Ok(())

--- a/columnar/src/columnar/merge/tests.rs
+++ b/columnar/src/columnar/merge/tests.rs
@@ -17,7 +17,12 @@ fn make_columnar<T: Into<NumericalValue> + HasAssociatedColumnType + Copy>(
     }
     let mut buffer: Vec<u8> = Vec::new();
     dataframe_writer
-        .serialize(vals.len() as RowId, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .serialize(
+            vals.len() as RowId,
+            None,
+            &crate::DEFAULT_CODEC_TYPES,
+            &mut buffer,
+        )
         .unwrap();
     ColumnarReader::open(buffer).unwrap()
 }
@@ -562,7 +567,14 @@ fn build_columnar(spec: &ColumnarSpec) -> ColumnarReader {
     }
 
     let mut buffer = Vec::new();
-    writer.serialize(max_row_id + 1, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
+    writer
+        .serialize(
+            max_row_id + 1,
+            None,
+            &crate::DEFAULT_CODEC_TYPES,
+            &mut buffer,
+        )
+        .unwrap();
     ColumnarReader::open(buffer).unwrap()
 }
 

--- a/columnar/src/columnar/merge/tests.rs
+++ b/columnar/src/columnar/merge/tests.rs
@@ -17,7 +17,7 @@ fn make_columnar<T: Into<NumericalValue> + HasAssociatedColumnType + Copy>(
     }
     let mut buffer: Vec<u8> = Vec::new();
     dataframe_writer
-        .serialize(vals.len() as RowId, None, &mut buffer)
+        .serialize(vals.len() as RowId, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
         .unwrap();
     ColumnarReader::open(buffer).unwrap()
 }
@@ -144,7 +144,7 @@ fn make_numerical_columnar_multiple_columns(
         .unwrap_or(0u32);
     let mut buffer: Vec<u8> = Vec::new();
     dataframe_writer
-        .serialize(num_rows, None, &mut buffer)
+        .serialize(num_rows, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
         .unwrap();
     ColumnarReader::open(buffer).unwrap()
 }
@@ -169,7 +169,7 @@ fn make_byte_columnar_multiple_columns(
     }
     let mut buffer: Vec<u8> = Vec::new();
     dataframe_writer
-        .serialize(num_rows, None, &mut buffer)
+        .serialize(num_rows, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
         .unwrap();
     ColumnarReader::open(buffer).unwrap()
 }
@@ -190,7 +190,7 @@ fn make_text_columnar_multiple_columns(columns: &[(&str, &[&[&str]])]) -> Column
         .unwrap_or(0u32);
     let mut buffer: Vec<u8> = Vec::new();
     dataframe_writer
-        .serialize(num_rows, None, &mut buffer)
+        .serialize(num_rows, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
         .unwrap();
     ColumnarReader::open(buffer).unwrap()
 }
@@ -210,6 +210,7 @@ fn test_merge_columnar_numbers() {
         columnars,
         &[],
         MergeRowOrder::Stack(stack_merge_order),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut buffer,
         || false,
     )
@@ -239,6 +240,7 @@ fn test_merge_columnar_texts() {
         columnars,
         &[],
         MergeRowOrder::Stack(stack_merge_order),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut buffer,
         || false,
     )
@@ -289,6 +291,7 @@ fn test_merge_columnar_byte() {
         columnars,
         &[],
         MergeRowOrder::Stack(stack_merge_order),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut buffer,
         || false,
     )
@@ -346,6 +349,7 @@ fn test_merge_columnar_byte_with_missing() {
         columnars,
         &[],
         MergeRowOrder::Stack(stack_merge_order),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut buffer,
         || false,
     )
@@ -399,6 +403,7 @@ fn test_merge_columnar_different_types() {
         columnars,
         &[],
         MergeRowOrder::Stack(stack_merge_order),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut buffer,
         || false,
     )
@@ -465,6 +470,7 @@ fn test_merge_columnar_different_empty_cardinality() {
         columnars,
         &[],
         MergeRowOrder::Stack(stack_merge_order),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut buffer,
         || false,
     )
@@ -556,7 +562,7 @@ fn build_columnar(spec: &ColumnarSpec) -> ColumnarReader {
     }
 
     let mut buffer = Vec::new();
-    writer.serialize(max_row_id + 1, None, &mut buffer).unwrap();
+    writer.serialize(max_row_id + 1, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
     ColumnarReader::open(buffer).unwrap()
 }
 
@@ -576,6 +582,7 @@ proptest! {
             &columnar_refs,
             &[],
             MergeRowOrder::Stack(stack_merge_order),
+            &crate::DEFAULT_CODEC_TYPES,
             &mut out,
             || false,
         ).unwrap();
@@ -594,6 +601,7 @@ proptest! {
             &columnar_refs,
             &[],
             MergeRowOrder::Stack(stack_merge_order),
+            &crate::DEFAULT_CODEC_TYPES,
             &mut out,
             || false,
         ).unwrap();

--- a/columnar/src/columnar/reader/mod.rs
+++ b/columnar/src/columnar/reader/mod.rs
@@ -226,7 +226,7 @@ mod tests {
         columnar_writer.record_column_type("col1", ColumnType::Str, false);
         columnar_writer.record_column_type("col2", ColumnType::U64, false);
         let mut buffer = Vec::new();
-        columnar_writer.serialize(1, None, &mut buffer).unwrap();
+        columnar_writer.serialize(1, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
         let columnar = ColumnarReader::open(buffer).unwrap();
         let columns = columnar.list_columns().unwrap();
         assert_eq!(columns.len(), 2);
@@ -242,7 +242,7 @@ mod tests {
         columnar_writer.record_column_type("count", ColumnType::U64, false);
         columnar_writer.record_numerical(1, "count", 1u64);
         let mut buffer = Vec::new();
-        columnar_writer.serialize(2, None, &mut buffer).unwrap();
+        columnar_writer.serialize(2, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
         let columnar = ColumnarReader::open(buffer).unwrap();
         let columns = columnar.list_columns().unwrap();
         assert_eq!(columns.len(), 1);
@@ -256,7 +256,7 @@ mod tests {
         columnar_writer.record_column_type("col", ColumnType::U64, false);
         columnar_writer.record_numerical(1, "col", 1u64);
         let mut buffer = Vec::new();
-        columnar_writer.serialize(2, None, &mut buffer).unwrap();
+        columnar_writer.serialize(2, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
         let columnar = ColumnarReader::open(buffer).unwrap();
         {
             let columns = columnar.read_columns("col").unwrap();
@@ -285,7 +285,7 @@ mod tests {
         columnar_writer.record_str(1, "col1", "hello");
         columnar_writer.record_str(0, "col2", "hello");
         let mut buffer = Vec::new();
-        columnar_writer.serialize(2, None, &mut buffer).unwrap();
+        columnar_writer.serialize(2, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
 
         let columnar = ColumnarReader::open(buffer).unwrap();
         {

--- a/columnar/src/columnar/reader/mod.rs
+++ b/columnar/src/columnar/reader/mod.rs
@@ -226,7 +226,9 @@ mod tests {
         columnar_writer.record_column_type("col1", ColumnType::Str, false);
         columnar_writer.record_column_type("col2", ColumnType::U64, false);
         let mut buffer = Vec::new();
-        columnar_writer.serialize(1, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
+        columnar_writer
+            .serialize(1, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+            .unwrap();
         let columnar = ColumnarReader::open(buffer).unwrap();
         let columns = columnar.list_columns().unwrap();
         assert_eq!(columns.len(), 2);
@@ -242,7 +244,9 @@ mod tests {
         columnar_writer.record_column_type("count", ColumnType::U64, false);
         columnar_writer.record_numerical(1, "count", 1u64);
         let mut buffer = Vec::new();
-        columnar_writer.serialize(2, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
+        columnar_writer
+            .serialize(2, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+            .unwrap();
         let columnar = ColumnarReader::open(buffer).unwrap();
         let columns = columnar.list_columns().unwrap();
         assert_eq!(columns.len(), 1);
@@ -256,7 +260,9 @@ mod tests {
         columnar_writer.record_column_type("col", ColumnType::U64, false);
         columnar_writer.record_numerical(1, "col", 1u64);
         let mut buffer = Vec::new();
-        columnar_writer.serialize(2, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
+        columnar_writer
+            .serialize(2, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+            .unwrap();
         let columnar = ColumnarReader::open(buffer).unwrap();
         {
             let columns = columnar.read_columns("col").unwrap();
@@ -285,7 +291,9 @@ mod tests {
         columnar_writer.record_str(1, "col1", "hello");
         columnar_writer.record_str(0, "col2", "hello");
         let mut buffer = Vec::new();
-        columnar_writer.serialize(2, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
+        columnar_writer
+            .serialize(2, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+            .unwrap();
 
         let columnar = ColumnarReader::open(buffer).unwrap();
         {

--- a/columnar/src/columnar/writer/mod.rs
+++ b/columnar/src/columnar/writer/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use serializer::ColumnarSerializer;
 use stacker::{Addr, ArenaHashMap, MemoryArena};
 
 use crate::column_index::{SerializableColumnIndex, SerializableOptionalIndex};
-use crate::column_values::{MonotonicallyMappableToU64, MonotonicallyMappableToU128};
+use crate::column_values::{CodecType, MonotonicallyMappableToU64, MonotonicallyMappableToU128};
 use crate::columnar::column_type::ColumnType;
 use crate::columnar::writer::column_writers::{
     ColumnWriter, NumericalColumnWriter, StrOrBytesColumnWriter,
@@ -44,7 +44,7 @@ struct SpareBuffers {
 /// columnar_writer.record_str(1u32 /* doc id */, "product_name", "Apple");
 /// columnar_writer.record_numerical(0u32 /* doc id */, "price", 10.5f64); //< uh oh we ended up mixing integer and floats.
 /// let mut wrt: Vec<u8> =  Vec::new();
-/// columnar_writer.serialize(2u32, None, &mut wrt).unwrap();
+/// columnar_writer.serialize(2u32, None, &tantivy_columnar::DEFAULT_CODEC_TYPES, &mut wrt).unwrap();
 /// ```
 #[derive(Default)]
 pub struct ColumnarWriter {
@@ -319,6 +319,7 @@ impl ColumnarWriter {
         &mut self,
         num_docs: RowId,
         old_to_new_row_ids: Option<&[RowId]>,
+        codec_types: &[CodecType],
         wrt: &mut dyn io::Write,
     ) -> io::Result<()> {
         let mut serializer = ColumnarSerializer::new(wrt);
@@ -383,6 +384,7 @@ impl ColumnarWriter {
                             &mut symbol_byte_buffer,
                         ),
                         buffers,
+                        codec_types,
                         &mut column_serializer,
                     )?;
                     column_serializer.finalize()?;
@@ -431,6 +433,7 @@ impl ColumnarWriter {
                         ),
                         buffers,
                         &self.arena,
+                        codec_types,
                         &mut column_serializer,
                     )?;
                     column_serializer.finalize()?;
@@ -452,6 +455,7 @@ impl ColumnarWriter {
                             &mut symbol_byte_buffer,
                         ),
                         buffers,
+                        codec_types,
                         &mut column_serializer,
                     )?;
                     column_serializer.finalize()?;
@@ -471,6 +475,7 @@ impl ColumnarWriter {
                             &mut symbol_byte_buffer,
                         ),
                         buffers,
+                        codec_types,
                         &mut column_serializer,
                     )?;
                     column_serializer.finalize()?;
@@ -543,6 +548,7 @@ fn serialize_bytes_or_str_column(
     operation_it: impl Iterator<Item = ColumnOperation<UnorderedId>>,
     buffers: &mut SpareBuffers,
     arena: &MemoryArena,
+    codec_types: &[CodecType],
     wrt: impl io::Write,
 ) -> io::Result<()> {
     let SpareBuffers {
@@ -572,6 +578,7 @@ fn serialize_bytes_or_str_column(
         sort_values_within_row,
         value_index_builders,
         u64_values,
+        codec_types,
         &mut wrt,
     )?;
     wrt.write_all(&dictionary_num_bytes.to_le_bytes()[..])?;
@@ -584,6 +591,7 @@ fn serialize_numerical_column(
     numerical_type: NumericalType,
     op_iterator: impl Iterator<Item = ColumnOperation<NumericalValue>>,
     buffers: &mut SpareBuffers,
+    codec_types: &[CodecType],
     wrt: &mut impl io::Write,
 ) -> io::Result<()> {
     let SpareBuffers {
@@ -600,6 +608,7 @@ fn serialize_numerical_column(
                 false,
                 value_index_builders,
                 u64_values,
+                codec_types,
                 wrt,
             )?;
         }
@@ -611,6 +620,7 @@ fn serialize_numerical_column(
                 false,
                 value_index_builders,
                 u64_values,
+                codec_types,
                 wrt,
             )?;
         }
@@ -622,6 +632,7 @@ fn serialize_numerical_column(
                 false,
                 value_index_builders,
                 u64_values,
+                codec_types,
                 wrt,
             )?;
         }
@@ -634,6 +645,7 @@ fn serialize_bool_column(
     num_docs: RowId,
     column_operations_it: impl Iterator<Item = ColumnOperation<bool>>,
     buffers: &mut SpareBuffers,
+    codec_types: &[CodecType],
     wrt: &mut impl io::Write,
 ) -> io::Result<()> {
     let SpareBuffers {
@@ -651,6 +663,7 @@ fn serialize_bool_column(
         false,
         value_index_builders,
         u64_values,
+        codec_types,
         wrt,
     )?;
     Ok(())
@@ -731,6 +744,7 @@ fn send_to_serialize_column_mappable_to_u64(
     sort_values_within_row: bool,
     value_index_builders: &mut PreallocatedIndexBuilders,
     values: &mut Vec<u64>,
+    codec_types: &[CodecType],
     mut wrt: impl io::Write,
 ) -> io::Result<()> {
     values.clear();
@@ -768,6 +782,7 @@ fn send_to_serialize_column_mappable_to_u64(
     crate::column::serialize_column_mappable_to_u64(
         serializable_column_index,
         &&values[..],
+        codec_types,
         &mut wrt,
     )?;
     Ok(())

--- a/columnar/src/compat_tests.rs
+++ b/columnar/src/compat_tests.rs
@@ -27,7 +27,7 @@ fn generate_columnar(num_docs: u32, value_offset: u64) -> Vec<u8> {
     }
 
     let mut wrt: Vec<u8> = Vec::new();
-    columnar_writer.serialize(num_docs, None, &mut wrt).unwrap();
+    columnar_writer.serialize(num_docs, None, &crate::DEFAULT_CODEC_TYPES, &mut wrt).unwrap();
 
     wrt
 }
@@ -75,6 +75,7 @@ fn test_format(path: &str) {
         &columnar_readers,
         &[],
         merge_row_order.into(),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut out,
         || false,
     )

--- a/columnar/src/compat_tests.rs
+++ b/columnar/src/compat_tests.rs
@@ -27,7 +27,9 @@ fn generate_columnar(num_docs: u32, value_offset: u64) -> Vec<u8> {
     }
 
     let mut wrt: Vec<u8> = Vec::new();
-    columnar_writer.serialize(num_docs, None, &crate::DEFAULT_CODEC_TYPES, &mut wrt).unwrap();
+    columnar_writer
+        .serialize(num_docs, None, &crate::DEFAULT_CODEC_TYPES, &mut wrt)
+        .unwrap();
 
     wrt
 }

--- a/columnar/src/lib.rs
+++ b/columnar/src/lib.rs
@@ -44,8 +44,7 @@ pub use column_values::{
 };
 
 /// Default codec types used for u64-based column serialization.
-pub const DEFAULT_CODEC_TYPES: [CodecType; 2] =
-    [CodecType::Bitpacked, CodecType::BlockwiseLinear];
+pub const DEFAULT_CODEC_TYPES: [CodecType; 2] = [CodecType::Bitpacked, CodecType::BlockwiseLinear];
 pub use columnar::{
     CURRENT_VERSION, ColumnType, ColumnarReader, ColumnarWriter, HasAssociatedColumnType,
     MergeRowOrder, ShuffleMergeOrder, StackMergeOrder, Version, compute_merged_term_ord_mapping,

--- a/columnar/src/lib.rs
+++ b/columnar/src/lib.rs
@@ -42,6 +42,10 @@ pub use column_values::{
     CodecType, ColumnStats, ColumnValues, EmptyColumnValues, MonotonicallyMappableToU64,
     MonotonicallyMappableToU128,
 };
+
+/// Default codec types used for u64-based column serialization.
+pub const DEFAULT_CODEC_TYPES: [CodecType; 2] =
+    [CodecType::Bitpacked, CodecType::BlockwiseLinear];
 pub use columnar::{
     CURRENT_VERSION, ColumnType, ColumnarReader, ColumnarWriter, HasAssociatedColumnType,
     MergeRowOrder, ShuffleMergeOrder, StackMergeOrder, Version, compute_merged_term_ord_mapping,

--- a/columnar/src/lib.rs
+++ b/columnar/src/lib.rs
@@ -39,8 +39,8 @@ pub use block_accessor::ColumnBlockAccessor;
 pub use column::{BytesColumn, Column, StrColumn};
 pub use column_index::ColumnIndex;
 pub use column_values::{
-    BlockwiseLinearV2Codec, BlockwiseLinearV2Reader, CodecType, ColumnCodec, ColumnStats,
-    ColumnValues, EmptyColumnValues, MonotonicallyMappableToU64, MonotonicallyMappableToU128,
+    CodecType, ColumnStats, ColumnValues, EmptyColumnValues, MonotonicallyMappableToU64,
+    MonotonicallyMappableToU128,
 };
 pub use columnar::{
     CURRENT_VERSION, ColumnType, ColumnarReader, ColumnarWriter, HasAssociatedColumnType,

--- a/columnar/src/lib.rs
+++ b/columnar/src/lib.rs
@@ -39,6 +39,7 @@ pub use block_accessor::ColumnBlockAccessor;
 pub use column::{BytesColumn, Column, StrColumn};
 pub use column_index::ColumnIndex;
 pub use column_values::{
+    BlockwiseLinearV2Codec, BlockwiseLinearV2Reader, CodecType, ColumnCodec, ColumnStats,
     ColumnValues, EmptyColumnValues, MonotonicallyMappableToU64, MonotonicallyMappableToU128,
 };
 pub use columnar::{

--- a/columnar/src/tests.rs
+++ b/columnar/src/tests.rs
@@ -21,7 +21,9 @@ fn test_dataframe_writer_str() {
     dataframe_writer.record_str(1u32, "my_string", "hello");
     dataframe_writer.record_str(3u32, "my_string", "helloeee");
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
+    dataframe_writer
+        .serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("my_string").unwrap();
@@ -35,7 +37,9 @@ fn test_dataframe_writer_bytes() {
     dataframe_writer.record_bytes(1u32, "my_string", b"hello");
     dataframe_writer.record_bytes(3u32, "my_string", b"helloeee");
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
+    dataframe_writer
+        .serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("my_string").unwrap();
@@ -49,7 +53,9 @@ fn test_dataframe_writer_bool() {
     dataframe_writer.record_bool(1u32, "bool.value", false);
     dataframe_writer.record_bool(3u32, "bool.value", true);
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
+    dataframe_writer
+        .serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("bool.value").unwrap();
@@ -74,7 +80,9 @@ fn test_dataframe_writer_u64_multivalued() {
     dataframe_writer.record_numerical(6u32, "divisor", 2u64);
     dataframe_writer.record_numerical(6u32, "divisor", 3u64);
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(7, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
+    dataframe_writer
+        .serialize(7, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("divisor").unwrap();
@@ -97,7 +105,9 @@ fn test_dataframe_writer_ip_addr() {
     dataframe_writer.record_ip_addr(1, "ip_addr", Ipv6Addr::from_u128(1001));
     dataframe_writer.record_ip_addr(3, "ip_addr", Ipv6Addr::from_u128(1050));
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
+    dataframe_writer
+        .serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("ip_addr").unwrap();
@@ -128,7 +138,9 @@ fn test_dataframe_writer_numerical() {
     dataframe_writer.record_numerical(2u32, "srical.value", NumericalValue::U64(13u64));
     dataframe_writer.record_numerical(4u32, "srical.value", NumericalValue::U64(15u64));
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(6, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
+    dataframe_writer
+        .serialize(6, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("srical.value").unwrap();
@@ -201,7 +213,9 @@ fn test_dictionary_encoded_str() {
     columnar_writer.record_str(3, "my.column", "c");
     columnar_writer.record_str(3, "my.column2", "different_column!");
     columnar_writer.record_str(4, "my.column", "b");
-    columnar_writer.serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
+    columnar_writer
+        .serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .unwrap();
     let columnar_reader = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar_reader.num_columns(), 2);
     let col_handles = columnar_reader.read_columns("my.column").unwrap();
@@ -235,7 +249,9 @@ fn test_dictionary_encoded_bytes() {
     columnar_writer.record_bytes(3, "my.column", b"c");
     columnar_writer.record_bytes(3, "my.column2", b"different_column!");
     columnar_writer.record_bytes(4, "my.column", b"b");
-    columnar_writer.serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
+    columnar_writer
+        .serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .unwrap();
     let columnar_reader = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar_reader.num_columns(), 2);
     let col_handles = columnar_reader.read_columns("my.column").unwrap();
@@ -504,7 +520,12 @@ fn build_columnar_with_mapping(
         }
     }
     columnar_writer
-        .serialize(num_docs, old_to_new_row_ids_opt, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .serialize(
+            num_docs,
+            old_to_new_row_ids_opt,
+            &crate::DEFAULT_CODEC_TYPES,
+            &mut buffer,
+        )
         .unwrap();
 
     ColumnarReader::open(buffer).unwrap()

--- a/columnar/src/tests.rs
+++ b/columnar/src/tests.rs
@@ -21,7 +21,7 @@ fn test_dataframe_writer_str() {
     dataframe_writer.record_str(1u32, "my_string", "hello");
     dataframe_writer.record_str(3u32, "my_string", "helloeee");
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(5, None, &mut buffer).unwrap();
+    dataframe_writer.serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("my_string").unwrap();
@@ -35,7 +35,7 @@ fn test_dataframe_writer_bytes() {
     dataframe_writer.record_bytes(1u32, "my_string", b"hello");
     dataframe_writer.record_bytes(3u32, "my_string", b"helloeee");
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(5, None, &mut buffer).unwrap();
+    dataframe_writer.serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("my_string").unwrap();
@@ -49,7 +49,7 @@ fn test_dataframe_writer_bool() {
     dataframe_writer.record_bool(1u32, "bool.value", false);
     dataframe_writer.record_bool(3u32, "bool.value", true);
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(5, None, &mut buffer).unwrap();
+    dataframe_writer.serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("bool.value").unwrap();
@@ -74,7 +74,7 @@ fn test_dataframe_writer_u64_multivalued() {
     dataframe_writer.record_numerical(6u32, "divisor", 2u64);
     dataframe_writer.record_numerical(6u32, "divisor", 3u64);
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(7, None, &mut buffer).unwrap();
+    dataframe_writer.serialize(7, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("divisor").unwrap();
@@ -97,7 +97,7 @@ fn test_dataframe_writer_ip_addr() {
     dataframe_writer.record_ip_addr(1, "ip_addr", Ipv6Addr::from_u128(1001));
     dataframe_writer.record_ip_addr(3, "ip_addr", Ipv6Addr::from_u128(1050));
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(5, None, &mut buffer).unwrap();
+    dataframe_writer.serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("ip_addr").unwrap();
@@ -128,7 +128,7 @@ fn test_dataframe_writer_numerical() {
     dataframe_writer.record_numerical(2u32, "srical.value", NumericalValue::U64(13u64));
     dataframe_writer.record_numerical(4u32, "srical.value", NumericalValue::U64(15u64));
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(6, None, &mut buffer).unwrap();
+    dataframe_writer.serialize(6, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("srical.value").unwrap();
@@ -201,7 +201,7 @@ fn test_dictionary_encoded_str() {
     columnar_writer.record_str(3, "my.column", "c");
     columnar_writer.record_str(3, "my.column2", "different_column!");
     columnar_writer.record_str(4, "my.column", "b");
-    columnar_writer.serialize(5, None, &mut buffer).unwrap();
+    columnar_writer.serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
     let columnar_reader = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar_reader.num_columns(), 2);
     let col_handles = columnar_reader.read_columns("my.column").unwrap();
@@ -235,7 +235,7 @@ fn test_dictionary_encoded_bytes() {
     columnar_writer.record_bytes(3, "my.column", b"c");
     columnar_writer.record_bytes(3, "my.column2", b"different_column!");
     columnar_writer.record_bytes(4, "my.column", b"b");
-    columnar_writer.serialize(5, None, &mut buffer).unwrap();
+    columnar_writer.serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer).unwrap();
     let columnar_reader = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar_reader.num_columns(), 2);
     let col_handles = columnar_reader.read_columns("my.column").unwrap();
@@ -504,7 +504,7 @@ fn build_columnar_with_mapping(
         }
     }
     columnar_writer
-        .serialize(num_docs, old_to_new_row_ids_opt, &mut buffer)
+        .serialize(num_docs, old_to_new_row_ids_opt, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
         .unwrap();
 
     ColumnarReader::open(buffer).unwrap()
@@ -832,7 +832,7 @@ proptest! {
         let columnar_readers_arr: Vec<&ColumnarReader> = columnar_readers.iter().collect();
         let mut output: Vec<u8> = Vec::new();
         let stack_merge_order = StackMergeOrder::stack(&columnar_readers_arr[..]).into();
-        crate::merge_columnar(&columnar_readers_arr[..], &[], stack_merge_order, &mut output, || false,).unwrap();
+        crate::merge_columnar(&columnar_readers_arr[..], &[], stack_merge_order, &crate::DEFAULT_CODEC_TYPES, &mut output, || false,).unwrap();
         let merged_columnar = ColumnarReader::open(output).unwrap();
         let concat_rows: Vec<Vec<(&'static str, ColumnValue)>> = columnar_docs.iter().flatten().cloned().collect();
         let expected_merged_columnar = build_columnar(&concat_rows[..]);
@@ -855,6 +855,7 @@ fn test_columnar_merging_empty_columnar() {
         &columnar_readers_arr[..],
         &[],
         crate::MergeRowOrder::Stack(stack_merge_order),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut output,
         || false,
     )
@@ -893,6 +894,7 @@ fn test_columnar_merging_number_columns() {
         &columnar_readers_arr[..],
         &[],
         crate::MergeRowOrder::Stack(stack_merge_order),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut output,
         || false,
     )
@@ -967,6 +969,7 @@ fn test_columnar_merge_and_remap(
         &columnar_readers_ref[..],
         &[],
         shuffle_merge_order.into(),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut output,
         || false,
     )
@@ -1010,6 +1013,7 @@ fn test_columnar_merge_empty() {
         &[&columnar_reader_1, &columnar_reader_2],
         &[],
         shuffle_merge_order.into(),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut output,
         || false,
     )
@@ -1037,6 +1041,7 @@ fn test_columnar_merge_single_str_column() {
         &[&columnar_reader_1, &columnar_reader_2],
         &[],
         shuffle_merge_order.into(),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut output,
         || false,
     )
@@ -1070,6 +1075,7 @@ fn test_delete_decrease_cardinality() {
         &[&columnar_reader_1, &columnar_reader_2],
         &[],
         shuffle_merge_order.into(),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut output,
         || false,
     )

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -127,7 +127,9 @@ mod tests {
             fast_field_writers
                 .add_document(&doc!(*FIELD=>2u64))
                 .unwrap();
-            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -178,7 +180,9 @@ mod tests {
             fast_field_writers
                 .add_document(&doc!(*FIELD=>215u64))
                 .unwrap();
-            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -211,7 +215,9 @@ mod tests {
                     .add_document(&doc!(*FIELD=>100_000u64))
                     .unwrap();
             }
-            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -243,7 +249,9 @@ mod tests {
                     .add_document(&doc!(*FIELD=>5_000_000_000_000_000_000u64 + doc_id))
                     .unwrap();
             }
-            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -276,7 +284,9 @@ mod tests {
                 doc.add_i64(i64_field, i);
                 fast_field_writers.add_document(&doc).unwrap();
             }
-            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -315,7 +325,9 @@ mod tests {
             let mut fast_field_writers = FastFieldsWriter::from_schema(&schema).unwrap();
             let doc = TantivyDocument::default();
             fast_field_writers.add_document(&doc).unwrap();
-            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
 
@@ -348,7 +360,9 @@ mod tests {
             let mut fast_field_writers = FastFieldsWriter::from_schema(&schema).unwrap();
             let doc = TantivyDocument::default();
             fast_field_writers.add_document(&doc).unwrap();
-            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
 
@@ -385,7 +399,9 @@ mod tests {
             for &x in &permutation {
                 fast_field_writers.add_document(&doc!(*FIELD=>x)).unwrap();
             }
-            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -770,7 +786,9 @@ mod tests {
             fast_field_writers
                 .add_document(&doc!(field=>false))
                 .unwrap();
-            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -802,7 +820,9 @@ mod tests {
                     .add_document(&doc!(field=>false))
                     .unwrap();
             }
-            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -827,7 +847,9 @@ mod tests {
             let mut fast_field_writers = FastFieldsWriter::from_schema(&schema).unwrap();
             let doc = TantivyDocument::default();
             fast_field_writers.add_document(&doc).unwrap();
-            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -855,7 +877,9 @@ mod tests {
             for doc in docs {
                 fast_field_writers.add_document(doc).unwrap();
             }
-            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         Ok(directory)

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -127,7 +127,7 @@ mod tests {
             fast_field_writers
                 .add_document(&doc!(*FIELD=>2u64))
                 .unwrap();
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -178,7 +178,7 @@ mod tests {
             fast_field_writers
                 .add_document(&doc!(*FIELD=>215u64))
                 .unwrap();
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -211,7 +211,7 @@ mod tests {
                     .add_document(&doc!(*FIELD=>100_000u64))
                     .unwrap();
             }
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -243,12 +243,11 @@ mod tests {
                     .add_document(&doc!(*FIELD=>5_000_000_000_000_000_000u64 + doc_id))
                     .unwrap();
             }
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        // V2 codec is selected here (BlockwiseLinearV2).
-        assert_eq!(file.len(), 4608);
+        assert_eq!(file.len(), 4476);
         {
             let fast_field_readers = FastFieldReaders::open(file, SCHEMA.clone()).unwrap();
             let col = fast_field_readers
@@ -277,12 +276,11 @@ mod tests {
                 doc.add_i64(i64_field, i);
                 fast_field_writers.add_document(&doc).unwrap();
             }
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        // V2 codec is selected here (BlockwiseLinearV2).
-        assert_eq!(file.len(), 513);
+        assert_eq!(file.len(), 252);
 
         {
             let fast_field_readers = FastFieldReaders::open(file, schema).unwrap();
@@ -317,7 +315,7 @@ mod tests {
             let mut fast_field_writers = FastFieldsWriter::from_schema(&schema).unwrap();
             let doc = TantivyDocument::default();
             fast_field_writers.add_document(&doc).unwrap();
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
             write.terminate().unwrap();
         }
 
@@ -350,7 +348,7 @@ mod tests {
             let mut fast_field_writers = FastFieldsWriter::from_schema(&schema).unwrap();
             let doc = TantivyDocument::default();
             fast_field_writers.add_document(&doc).unwrap();
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
             write.terminate().unwrap();
         }
 
@@ -387,7 +385,7 @@ mod tests {
             for &x in &permutation {
                 fast_field_writers.add_document(&doc!(*FIELD=>x)).unwrap();
             }
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -772,7 +770,7 @@ mod tests {
             fast_field_writers
                 .add_document(&doc!(field=>false))
                 .unwrap();
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -804,7 +802,7 @@ mod tests {
                     .add_document(&doc!(field=>false))
                     .unwrap();
             }
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -829,7 +827,7 @@ mod tests {
             let mut fast_field_writers = FastFieldsWriter::from_schema(&schema).unwrap();
             let doc = TantivyDocument::default();
             fast_field_writers.add_document(&doc).unwrap();
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -857,7 +855,7 @@ mod tests {
             for doc in docs {
                 fast_field_writers.add_document(doc).unwrap();
             }
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers.serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None).unwrap();
             write.terminate().unwrap();
         }
         Ok(directory)

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -247,7 +247,8 @@ mod tests {
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 4476);
+        // V2 codec is selected here (BlockwiseLinearV2).
+        assert_eq!(file.len(), 4608);
         {
             let fast_field_readers = FastFieldReaders::open(file, SCHEMA.clone()).unwrap();
             let col = fast_field_readers
@@ -280,7 +281,8 @@ mod tests {
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 252);
+        // V2 codec is selected here (BlockwiseLinearV2).
+        assert_eq!(file.len(), 513);
 
         {
             let fast_field_readers = FastFieldReaders::open(file, schema).unwrap();

--- a/src/fastfield/writer.rs
+++ b/src/fastfield/writer.rs
@@ -393,7 +393,12 @@ mod tests {
         }
         let mut buffer = Vec::new();
         columnar_writer
-            .serialize(json_docs.len() as DocId, None, &columnar::DEFAULT_CODEC_TYPES, &mut buffer)
+            .serialize(
+                json_docs.len() as DocId,
+                None,
+                &columnar::DEFAULT_CODEC_TYPES,
+                &mut buffer,
+            )
             .unwrap();
         ColumnarReader::open(buffer).unwrap()
     }

--- a/src/fastfield/writer.rs
+++ b/src/fastfield/writer.rs
@@ -235,6 +235,7 @@ impl FastFieldsWriter {
     /// order to the fast field serializer.
     pub fn serialize(
         mut self,
+        codec_types: &[columnar::CodecType],
         wrt: &mut dyn io::Write,
         doc_id_map_opt: Option<&DocIdMapping>,
     ) -> io::Result<()> {
@@ -242,7 +243,7 @@ impl FastFieldsWriter {
         let old_to_new_row_ids =
             doc_id_map_opt.map(|doc_id_mapping| doc_id_mapping.old_to_new_ids());
         self.columnar_writer
-            .serialize(num_docs, old_to_new_row_ids, wrt)?;
+            .serialize(num_docs, old_to_new_row_ids, codec_types, wrt)?;
         Ok(())
     }
 }
@@ -392,7 +393,7 @@ mod tests {
         }
         let mut buffer = Vec::new();
         columnar_writer
-            .serialize(json_docs.len() as DocId, None, &mut buffer)
+            .serialize(json_docs.len() as DocId, None, &columnar::DEFAULT_CODEC_TYPES, &mut buffer)
             .unwrap();
         ColumnarReader::open(buffer).unwrap()
     }

--- a/src/index/index_meta.rs
+++ b/src/index/index_meta.rs
@@ -310,6 +310,11 @@ pub struct IndexSettings {
     #[serde(default = "default_docstore_blocksize")]
     /// The size of each block that will be compressed and written to disk
     pub docstore_blocksize: usize,
+    /// Codec types for u64-based column serialization.
+    /// Empty means use the default: `[Bitpacked, BlockwiseLinear]`.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub codec_types: Vec<columnar::CodecType>,
 }
 
 /// Must be a function to be compatible with serde defaults
@@ -324,6 +329,18 @@ impl Default for IndexSettings {
             docstore_compression: Compressor::default(),
             docstore_blocksize: default_docstore_blocksize(),
             docstore_compress_dedicated_thread: true,
+            codec_types: Vec::new(),
+        }
+    }
+}
+
+impl IndexSettings {
+    /// Returns the codec types to use for u64-based column serialization.
+    pub fn columnar_codec_types(&self) -> &[columnar::CodecType] {
+        if self.codec_types.is_empty() {
+            &columnar::DEFAULT_CODEC_TYPES
+        } else {
+            &self.codec_types
         }
     }
 }
@@ -579,7 +596,8 @@ mod tests {
                 sort_by_field: None,
                 docstore_compression: Compressor::default(),
                 docstore_compress_dedicated_thread: true,
-                docstore_blocksize: 16_384
+                docstore_blocksize: 16_384,
+                codec_types: Vec::new(),
             }
         );
         {
@@ -610,5 +628,46 @@ mod tests {
                 serde_json::from_value(index_settings_json).unwrap();
             assert_eq!(index_settings_deser, index_settings);
         }
+    }
+
+    #[test]
+    fn test_codec_types_settings() {
+        use columnar::CodecType;
+
+        // Empty codec_types = default (V1)
+        let settings = IndexSettings::default();
+        assert_eq!(
+            settings.columnar_codec_types(),
+            &[CodecType::Bitpacked, CodecType::BlockwiseLinear]
+        );
+
+        // Explicit codec_types round-trips through JSON
+        let settings = IndexSettings {
+            codec_types: vec![CodecType::Bitpacked, CodecType::BlockwiseLinearV2],
+            ..IndexSettings::default()
+        };
+        let json = serde_json::to_value(&settings).unwrap();
+        assert_eq!(
+            json["codec_types"],
+            serde_json::json!(["Bitpacked", "BlockwiseLinearV2"])
+        );
+        let deser: IndexSettings = serde_json::from_value(json).unwrap();
+        assert_eq!(deser.codec_types, vec![CodecType::Bitpacked, CodecType::BlockwiseLinearV2]);
+        assert_eq!(
+            deser.columnar_codec_types(),
+            &[CodecType::Bitpacked, CodecType::BlockwiseLinearV2]
+        );
+
+        // Missing codec_types in JSON = empty vec = default (V1)
+        let json = serde_json::json!({
+            "docstore_compression": "lz4",
+            "docstore_blocksize": 16384
+        });
+        let deser: IndexSettings = serde_json::from_value(json).unwrap();
+        assert!(deser.codec_types.is_empty());
+        assert_eq!(
+            deser.columnar_codec_types(),
+            &[CodecType::Bitpacked, CodecType::BlockwiseLinear]
+        );
     }
 }

--- a/src/index/index_meta.rs
+++ b/src/index/index_meta.rs
@@ -311,15 +311,22 @@ pub struct IndexSettings {
     /// The size of each block that will be compressed and written to disk
     pub docstore_blocksize: usize,
     /// Codec types for u64-based column serialization.
-    /// Empty means use the default: `[Bitpacked, BlockwiseLinear]`.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default = "default_codec_types")]
+    #[serde(skip_serializing_if = "is_default_codec_types")]
     pub codec_types: Vec<columnar::CodecType>,
 }
 
 /// Must be a function to be compatible with serde defaults
 fn default_docstore_blocksize() -> usize {
     16_384
+}
+
+fn default_codec_types() -> Vec<columnar::CodecType> {
+    columnar::DEFAULT_CODEC_TYPES.to_vec()
+}
+
+fn is_default_codec_types(types: &[columnar::CodecType]) -> bool {
+    types == columnar::DEFAULT_CODEC_TYPES
 }
 
 impl Default for IndexSettings {
@@ -329,7 +336,7 @@ impl Default for IndexSettings {
             docstore_compression: Compressor::default(),
             docstore_blocksize: default_docstore_blocksize(),
             docstore_compress_dedicated_thread: true,
-            codec_types: Vec::new(),
+            codec_types: default_codec_types(),
         }
     }
 }
@@ -337,11 +344,7 @@ impl Default for IndexSettings {
 impl IndexSettings {
     /// Returns the codec types to use for u64-based column serialization.
     pub fn columnar_codec_types(&self) -> &[columnar::CodecType] {
-        if self.codec_types.is_empty() {
-            &columnar::DEFAULT_CODEC_TYPES
-        } else {
-            &self.codec_types
-        }
+        &self.codec_types
     }
 }
 
@@ -530,6 +533,7 @@ mod tests {
                 }),
                 docstore_blocksize: 1_000_000,
                 docstore_compress_dedicated_thread: true,
+                ..IndexSettings::default()
             },
             segments: Vec::new(),
             schema,
@@ -597,7 +601,7 @@ mod tests {
                 docstore_compression: Compressor::default(),
                 docstore_compress_dedicated_thread: true,
                 docstore_blocksize: 16_384,
-                codec_types: Vec::new(),
+                codec_types: columnar::DEFAULT_CODEC_TYPES.to_vec(),
             }
         );
         {
@@ -661,13 +665,12 @@ mod tests {
             &[CodecType::Bitpacked, CodecType::BlockwiseLinearV2]
         );
 
-        // Missing codec_types in JSON = empty vec = default (V1)
+        // Missing codec_types in JSON = default (V1)
         let json = serde_json::json!({
             "docstore_compression": "lz4",
             "docstore_blocksize": 16384
         });
         let deser: IndexSettings = serde_json::from_value(json).unwrap();
-        assert!(deser.codec_types.is_empty());
         assert_eq!(
             deser.columnar_codec_types(),
             &[CodecType::Bitpacked, CodecType::BlockwiseLinear]

--- a/src/index/index_meta.rs
+++ b/src/index/index_meta.rs
@@ -652,7 +652,10 @@ mod tests {
             serde_json::json!(["Bitpacked", "BlockwiseLinearV2"])
         );
         let deser: IndexSettings = serde_json::from_value(json).unwrap();
-        assert_eq!(deser.codec_types, vec![CodecType::Bitpacked, CodecType::BlockwiseLinearV2]);
+        assert_eq!(
+            deser.codec_types,
+            vec![CodecType::Bitpacked, CodecType::BlockwiseLinearV2]
+        );
         assert_eq!(
             deser.columnar_codec_types(),
             &[CodecType::Bitpacked, CodecType::BlockwiseLinearV2]

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -374,6 +374,7 @@ impl IndexMerger {
             &columnars[..],
             &required_columns,
             merge_row_order,
+            &self.index_settings.columnar_codec_types(),
             fast_field_wrt,
             || self.cancel.wants_cancel(),
         )?;
@@ -2265,5 +2266,54 @@ mod tests {
         // this is the first time I write a unit test for a constant.
         assert!(((super::MAX_DOC_LIMIT - 1) as i32) >= 0);
         assert!((super::MAX_DOC_LIMIT as i32) < 0);
+    }
+
+    #[test]
+    fn test_merge_respects_codec_types_setting() -> crate::Result<()> {
+        use crate::IndexSettings;
+        use crate::schema::Schema;
+        use columnar::CodecType;
+
+        // Create index with BlockwiseLinearV2 codec setting
+        let mut schema_builder = Schema::builder();
+        let u64_field = schema_builder.add_u64_field("val", FAST);
+        let schema = schema_builder.build();
+        let settings = IndexSettings {
+            codec_types: vec![CodecType::Bitpacked, CodecType::BlockwiseLinearV2],
+            ..IndexSettings::default()
+        };
+        let index = Index::builder()
+            .schema(schema)
+            .settings(settings)
+            .create_in_ram()?;
+
+        // Write two segments
+        let mut writer = index.writer_for_tests()?;
+        for i in 0u64..100 {
+            writer.add_document(doc!(u64_field => i))?;
+        }
+        writer.commit()?;
+        for i in 100u64..200 {
+            writer.add_document(doc!(u64_field => i))?;
+        }
+        writer.commit()?;
+
+        // Verify the setting is persisted
+        assert_eq!(
+            index.settings().codec_types,
+            vec![CodecType::Bitpacked, CodecType::BlockwiseLinearV2]
+        );
+
+        // Merge the two segments
+        let segment_ids: Vec<_> = index.searchable_segment_ids()?;
+        assert_eq!(segment_ids.len(), 2);
+        writer.merge_foreground(&segment_ids, true)?;
+
+        // Verify merge produced a single segment and data is intact
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        assert_eq!(searcher.num_docs(), 200);
+
+        Ok(())
     }
 }

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -2270,9 +2270,10 @@ mod tests {
 
     #[test]
     fn test_merge_respects_codec_types_setting() -> crate::Result<()> {
-        use crate::IndexSettings;
-        use crate::schema::Schema;
         use columnar::CodecType;
+
+        use crate::schema::Schema;
+        use crate::IndexSettings;
 
         // Create index with BlockwiseLinearV2 codec setting
         let mut schema_builder = Schema::builder();

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -452,7 +452,11 @@ fn remap_and_write(
         serializer.get_postings_serializer(),
     )?;
     debug!("fastfield-serialize");
-    fast_field_writers.serialize(columnar_codec_types, serializer.get_fast_field_write(), doc_id_map)?;
+    fast_field_writers.serialize(
+        columnar_codec_types,
+        serializer.get_fast_field_write(),
+        doc_id_map,
+    )?;
 
     // finalize temp docstore and create version, which reflects the doc_id_map
     if !ignore_store {

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -75,6 +75,7 @@ pub struct SegmentWriter {
     term_buffer: IndexingTerm,
     schema: Schema,
     ignore_store: bool,
+    columnar_codec_types: Vec<columnar::CodecType>,
 }
 
 impl SegmentWriter {
@@ -96,6 +97,7 @@ impl SegmentWriter {
         let tokenizer_manager = segment.index().tokenizers().clone();
         let tokenizer_manager_fast_field = segment.index().fast_field_tokenizer().clone();
         let table_size = compute_initial_table_size(memory_budget_in_bytes)?;
+        let columnar_codec_types = segment.index().settings().columnar_codec_types().to_vec();
         let segment_serializer = SegmentSerializer::for_segment(segment, false)?;
         let per_field_postings_writers = PerFieldPostingsWriter::for_schema(&schema);
         let per_field_text_analyzers = schema
@@ -137,6 +139,7 @@ impl SegmentWriter {
             term_buffer: IndexingTerm::with_capacity(16),
             schema,
             ignore_store,
+            columnar_codec_types,
         })
     }
 
@@ -164,6 +167,7 @@ impl SegmentWriter {
             self.segment_serializer,
             mapping.as_ref(),
             self.ignore_store,
+            &self.columnar_codec_types,
         )?;
         let doc_opstamps = remap_doc_opstamps(self.doc_opstamps, mapping.as_ref());
         Ok(doc_opstamps)
@@ -429,6 +433,7 @@ fn remap_and_write(
     mut serializer: SegmentSerializer,
     doc_id_map: Option<&DocIdMapping>,
     ignore_store: bool,
+    columnar_codec_types: &[columnar::CodecType],
 ) -> crate::Result<()> {
     debug!("remap-and-write");
     if let Some(fieldnorms_serializer) = serializer.extract_fieldnorms_serializer() {
@@ -447,7 +452,7 @@ fn remap_and_write(
         serializer.get_postings_serializer(),
     )?;
     debug!("fastfield-serialize");
-    fast_field_writers.serialize(serializer.get_fast_field_write(), doc_id_map)?;
+    fast_field_writers.serialize(columnar_codec_types, serializer.get_fast_field_write(), doc_id_map)?;
 
     // finalize temp docstore and create version, which reflects the doc_id_map
     if !ignore_store {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,10 +168,8 @@ mod macros;
 mod future_result;
 
 // Re-exports
-pub use columnar;
 pub use common::{ByteCount, DateTime};
-pub use query_grammar;
-pub use time;
+pub use {columnar, query_grammar, time};
 
 pub use crate::error::TantivyError;
 pub use crate::future_result::FutureResult;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,8 +168,10 @@ mod macros;
 mod future_result;
 
 // Re-exports
+pub use columnar;
 pub use common::{ByteCount, DateTime};
-pub use {columnar, query_grammar, time};
+pub use query_grammar;
+pub use time;
 
 pub use crate::error::TantivyError;
 pub use crate::future_result::FutureResult;


### PR DESCRIPTION
New BlockwiseLinearV2 u64 column codec with fixed-size footer entries for O(1) block lookup. All codec data remains identical.

  - Lazy load() — footer kept as FileSlice, never eagerly read. Block metadata parsed on demand (21 bytes per block) only for accessed blocks. Near-zero load cost for TopK queries.
  - Block-aware get_row_ids_for_value_range — reads footer range in one read_bytes() upfront, then one read_bytes() per block. Replaces the default per-row get_val loop for filtered range queries.
  - Single-entry parking lot protected block cache in get_val — sequential doc ID access hits the cache ~512 times per block, reducing read_bytes calls from O(N) to O(N/512) for bulk queries.

V2's metadata footer is roughly 2-4x larger per block than V1's. For 1M rows that's ~2000 blocks × 21 bytes = ~42KB of footer in V2, vs maybe ~12-18KB in V1. Negligible relative to the data itself, but it is larger. The fixed size is what enables O(1) block lookup and lazy loading.

This isn't a breaking change, but going back to a previous version will require a `REINDEX` 