### PR TITLE
fix: Missing sentinel is now considered in term agg requests with exclude + missing

### DIFF
--- a/columnar/src/column/mod.rs
+++ b/columnar/src/column/mod.rs
@@ -84,10 +84,6 @@ impl<T: PartialOrd + Copy + Debug + Send + Sync + 'static> Column<T> {
         self.values.max_value()
     }
 
-    pub fn num_vals(&self) -> u32 {
-        self.values.num_vals()
-    }
-
     #[inline]
     pub fn first(&self, doc_id: DocId) -> Option<T> {
         self.values_for_doc(doc_id).next()

--- a/columnar/src/column/mod.rs
+++ b/columnar/src/column/mod.rs
@@ -84,6 +84,10 @@ impl<T: PartialOrd + Copy + Debug + Send + Sync + 'static> Column<T> {
         self.values.max_value()
     }
 
+    pub fn num_vals(&self) -> u32 {
+        self.values.num_vals()
+    }
+
     #[inline]
     pub fn first(&self, doc_id: DocId) -> Option<T> {
         self.values_for_doc(doc_id).next()

--- a/src/aggregation/accessor_helpers.rs
+++ b/src/aggregation/accessor_helpers.rs
@@ -7,6 +7,18 @@ use columnar::{Column, ColumnType};
 use crate::aggregation::{f64_to_fastfield_u64, Key};
 use crate::index::SegmentReader;
 
+/// For string columns, the missing value is always represented as column_max_value + 1, but in
+/// the case where we have no values for this column, that causes the missing value to be
+/// erroneously set to 1 (which would imply we had one additional value represented as 0).
+/// This checks for that case that case and returns 0 instead.
+fn missing_val_for_str_cols(column_max_value: u64, column_num_values: u32) -> u64 {
+    if column_num_values == 0 {
+        0
+    } else {
+        column_max_value + 1
+    }
+}
+
 /// Get the missing value as internal u64 representation
 ///
 /// For terms we use u64::MAX as sentinel value
@@ -17,15 +29,28 @@ use crate::index::SegmentReader;
 pub(crate) fn get_missing_val_as_u64_lenient(
     column_type: ColumnType,
     column_max_value: u64,
+    column_num_values: u32,
     missing: &Key,
     field_name: &str,
 ) -> crate::Result<Option<u64>> {
     let missing_val = match missing {
-        Key::Str(_) if column_type == ColumnType::Str => Some(column_max_value + 1),
+        Key::Str(_) if column_type == ColumnType::Str => Some(missing_val_for_str_cols(
+            column_max_value,
+            column_num_values,
+        )),
         // Allow fallback to number on text fields
-        Key::F64(_) if column_type == ColumnType::Str => Some(column_max_value + 1),
-        Key::U64(_) if column_type == ColumnType::Str => Some(column_max_value + 1),
-        Key::I64(_) if column_type == ColumnType::Str => Some(column_max_value + 1),
+        Key::F64(_) if column_type == ColumnType::Str => Some(missing_val_for_str_cols(
+            column_max_value,
+            column_num_values,
+        )),
+        Key::U64(_) if column_type == ColumnType::Str => Some(missing_val_for_str_cols(
+            column_max_value,
+            column_num_values,
+        )),
+        Key::I64(_) if column_type == ColumnType::Str => Some(missing_val_for_str_cols(
+            column_max_value,
+            column_num_values,
+        )),
         Key::F64(val) if column_type.numerical_type().is_some() => {
             f64_to_fastfield_u64(*val, &column_type)
         }

--- a/src/aggregation/accessor_helpers.rs
+++ b/src/aggregation/accessor_helpers.rs
@@ -7,18 +7,6 @@ use columnar::{Column, ColumnType};
 use crate::aggregation::{f64_to_fastfield_u64, Key};
 use crate::index::SegmentReader;
 
-/// For string columns, the missing value is always represented as column_max_value + 1, but in
-/// the case where we have no values for this column, that causes the missing value to be
-/// erroneously set to 1 (which would imply we had one additional value represented as 0).
-/// This checks for that case that case and returns 0 instead.
-fn missing_val_for_str_cols(column_max_value: u64, column_num_values: u32) -> u64 {
-    if column_num_values == 0 {
-        0
-    } else {
-        column_max_value + 1
-    }
-}
-
 /// Get the missing value as internal u64 representation
 ///
 /// For terms we use u64::MAX as sentinel value
@@ -28,29 +16,16 @@ fn missing_val_for_str_cols(column_max_value: u64, column_num_values: u32) -> u6
 /// That way we can use it the same way as if it would come from the fastfield.
 pub(crate) fn get_missing_val_as_u64_lenient(
     column_type: ColumnType,
-    column_max_value: u64,
-    column_num_values: u32,
+    column_val_count: u32,
     missing: &Key,
     field_name: &str,
 ) -> crate::Result<Option<u64>> {
     let missing_val = match missing {
-        Key::Str(_) if column_type == ColumnType::Str => Some(missing_val_for_str_cols(
-            column_max_value,
-            column_num_values,
-        )),
-        // Allow fallback to number on text fields
-        Key::F64(_) if column_type == ColumnType::Str => Some(missing_val_for_str_cols(
-            column_max_value,
-            column_num_values,
-        )),
-        Key::U64(_) if column_type == ColumnType::Str => Some(missing_val_for_str_cols(
-            column_max_value,
-            column_num_values,
-        )),
-        Key::I64(_) if column_type == ColumnType::Str => Some(missing_val_for_str_cols(
-            column_max_value,
-            column_num_values,
-        )),
+        Key::Str(_) | Key::F64(_) | Key::U64(_) | Key::I64(_) if column_type == ColumnType::Str => {
+            // For strings, we use the max term ordinal + 1, which happens to always be the same as
+            // the number of values in the column
+            Some(column_val_count as u64)
+        }
         Key::F64(val) if column_type.numerical_type().is_some() => {
             f64_to_fastfield_u64(*val, &column_type)
         }

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -967,13 +967,7 @@ fn build_terms_or_cardinality_nodes(
         let missing_value_for_accessor = if use_special_missing_agg {
             None
         } else if let Some(m) = missing.as_ref() {
-            get_missing_val_as_u64_lenient(
-                column_type,
-                accessor.max_value(),
-                accessor.num_vals(),
-                m,
-                field_name,
-            )?
+            get_missing_val_as_u64_lenient(column_type, accessor.values.num_vals(), m, field_name)?
         } else {
             None
         };

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -967,7 +967,13 @@ fn build_terms_or_cardinality_nodes(
         let missing_value_for_accessor = if use_special_missing_agg {
             None
         } else if let Some(m) = missing.as_ref() {
-            get_missing_val_as_u64_lenient(column_type, accessor.max_value(), m, field_name)?
+            get_missing_val_as_u64_lenient(
+                column_type,
+                accessor.max_value(),
+                accessor.num_vals(),
+                m,
+                field_name,
+            )?
         } else {
             None
         };

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -2959,6 +2959,38 @@ mod tests {
     }
 
     #[test]
+    fn terms_agg_request_with_exclude_returns_missing_term_bucket() -> crate::Result<()> {
+        let exclude_req: Aggregations = serde_json::from_value(json!({
+            "my_bool": {
+                "terms": {
+                    "field": "title",
+                    "exclude": "foo(.*)",
+                    "missing": "__NULL__",
+                    "size": 1000,
+                }
+            }
+        }))?;
+
+        // zero unique terms case
+        let index = prep_index_with_n_unique_terms_plus_one_null(0)?;
+
+        let res = exec_request(exclude_req.clone(), &index)?;
+        let buckets = res["my_bool"]["buckets"].as_array().unwrap();
+        assert_eq!(buckets.len(), 1);
+        assert_eq!(buckets[0]["key"], "__NULL__");
+
+        // non-zero unique terms case
+        let index = prep_index_with_n_unique_terms_plus_one_null(64)?;
+
+        let res = exec_request(exclude_req, &index)?;
+        let buckets = res["my_bool"]["buckets"].as_array().unwrap();
+        assert_eq!(buckets.len(), 1);
+        assert_eq!(buckets[0]["key"], "__NULL__");
+
+        Ok(())
+    }
+
+    #[test]
     fn null_bitset_bounds_check_regression() -> crate::Result<()> {
         // include cases
         for i in 0..=4 {
@@ -3016,16 +3048,13 @@ mod tests {
 
             let exclude_res = exec_request(exclude_req, &index)?;
             let exclude_buckets = exclude_res["my_bool"]["buckets"].as_array().unwrap();
-            if i != 0 {
-                // TODO: Remove this if after fixing exclude + missing bug
-                assert_eq!(
-                    exclude_buckets.len(),
-                    1,
-                    "The exclude request should exclude all 'foo' buckets, and only the missing \
-                     term bucket",
-                );
-                assert_eq!(exclude_buckets[0]["key"], "__NULL__");
-            }
+            assert_eq!(
+                exclude_buckets.len(),
+                1,
+                "The exclude request should exclude all 'foo' buckets, and only the missing term \
+                 bucket",
+            );
+            assert_eq!(exclude_buckets[0]["key"], "__NULL__");
         }
         Ok(())
     }


### PR DESCRIPTION
The missing sentinel value is computed as (this name is descriptive, not a reference ->) `max_term_ordinal + 1`. When there are zero unique terms, this causes the sentinel value to be 1 (because `max_term_ordinal` is 0 by default), which means the allowed terms bitset never contains it (because it will only have capacity 1 in this case).

This fix adds logic to handle that by considering the number of unique values in the column when computing the missing sentinel value.

(Ideally we'd have distinct representations for the max term ordinal of zero unique terms and one unique term, but that would be much broader refactor)