### PR TITLE
  Move single-term BMW optimization from BooleanWeight to scorer_union/block_wand

### DIFF
--- a/src/query/boolean_query/block_wand.rs
+++ b/src/query/boolean_query/block_wand.rs
@@ -150,6 +150,9 @@ pub fn block_wand(
     mut threshold: Score,
     callback: &mut dyn FnMut(u32, Score) -> Score,
 ) {
+    if scorers.len() == 1 {
+        return block_wand_single_scorer(scorers.pop().unwrap(), threshold, callback);
+    }
     let mut scorers: Vec<TermScorerWithMaxScore> = scorers
         .iter_mut()
         .map(TermScorerWithMaxScore::from)

--- a/src/query/boolean_query/boolean_weight.rs
+++ b/src/query/boolean_query/boolean_weight.rs
@@ -49,9 +49,6 @@ where
     TScoreCombiner: ScoreCombiner,
 {
     assert!(!scorers.is_empty());
-    if scorers.len() == 1 {
-        return SpecializedScorer::Other(scorers.into_iter().next().unwrap()); //< we checked the size beforehand
-    }
 
     {
         let is_all_term_queries = scorers.iter().all(|scorer| scorer.is::<TermScorer>());
@@ -64,8 +61,11 @@ where
                 .iter()
                 .all(|scorer| scorer.freq_reading_option() == FreqReadingOption::ReadFreq)
             {
-                // Block wand is only available if we read frequencies.
+                // Block wand is available when we read frequencies.
+                // block_wand handles both single and multi-scorer cases.
                 return SpecializedScorer::TermUnion(scorers);
+            } else if scorers.len() == 1 {
+                return SpecializedScorer::Other(Box::new(scorers.into_iter().next().unwrap()));
             } else {
                 return SpecializedScorer::Other(Box::new(BufferedUnionScorer::build(
                     scorers,
@@ -74,6 +74,9 @@ where
                 )));
             }
         }
+    }
+    if scorers.len() == 1 {
+        return SpecializedScorer::Other(scorers.into_iter().next().unwrap());
     }
     SpecializedScorer::Other(Box::new(BufferedUnionScorer::build(
         scorers,
@@ -519,17 +522,6 @@ impl<TScoreCombiner: ScoreCombiner + Sync> Weight for BooleanWeight<TScoreCombin
         reader: &SegmentReader,
         callback: &mut dyn FnMut(DocId, Score) -> Score,
     ) -> crate::Result<()> {
-        // When there is a single include clause, delegate directly to the child
-        // weight's for_each_pruning. This ensures that e.g. a BooleanQuery
-        // wrapping a single TermQuery still benefits from block-max WAND
-        // pruning (via TermWeight::for_each_pruning), rather than falling
-        // through to the generic for_each_pruning_scorer loop.
-        if self.scoring_enabled && self.weights.len() == 1 {
-            let (occur, weight) = &self.weights[0];
-            if is_include_occur(*occur) {
-                return weight.for_each_pruning(threshold, reader, callback);
-            }
-        }
         let scorer = self.complex_scorer(reader, 1.0, &self.score_combiner_fn)?;
         match scorer {
             SpecializedScorer::TermUnion(term_scorers) => {

--- a/src/query/boolean_query/boolean_weight.rs
+++ b/src/query/boolean_query/boolean_weight.rs
@@ -519,6 +519,17 @@ impl<TScoreCombiner: ScoreCombiner + Sync> Weight for BooleanWeight<TScoreCombin
         reader: &SegmentReader,
         callback: &mut dyn FnMut(DocId, Score) -> Score,
     ) -> crate::Result<()> {
+        // When there is a single include clause, delegate directly to the child
+        // weight's for_each_pruning. This ensures that e.g. a BooleanQuery
+        // wrapping a single TermQuery still benefits from block-max WAND
+        // pruning (via TermWeight::for_each_pruning), rather than falling
+        // through to the generic for_each_pruning_scorer loop.
+        if self.scoring_enabled && self.weights.len() == 1 {
+            let (occur, weight) = &self.weights[0];
+            if is_include_occur(*occur) {
+                return weight.for_each_pruning(threshold, reader, callback);
+            }
+        }
         let scorer = self.complex_scorer(reader, 1.0, &self.score_combiner_fn)?;
         match scorer {
             SpecializedScorer::TermUnion(term_scorers) => {


### PR DESCRIPTION
Based on feedback from Paul.

Instead of checking weights.len() == 1 in BooleanWeight::for_each_pruning (which only catches BooleanQueries constructed with a single clause), fix the root cause: scorer_union now returns TermUnion for a single TermScorer with  freq reading, and block_wand delegates to block_wand_single_scorer when  given a single scorer. This also handles cases where EmptyScorer filtering reduces multiple clauses to one.