### PR TITLE
chore: Revert "feat: Lazy fieldnorm reader (#123)"

### DIFF
--- a/common/src/file_slice.rs
+++ b/common/src/file_slice.rs
@@ -32,25 +32,6 @@ pub trait FileHandle: 'static + Send + Sync + HasLen + fmt::Debug {
             "Async read is not supported.",
         ))
     }
-
-    /// Reads a single byte without allocating OwnedBytes.
-    ///
-    /// Default implementation goes through `read_bytes()`.
-    /// Implementations backed by block caches can override this for
-    /// zero-allocation access.
-    fn read_byte(&self, offset: usize) -> io::Result<u8> {
-        let data = self.read_bytes(offset..offset + 1)?;
-        Ok(data[0])
-    }
-
-    /// Returns a direct reference to the underlying bytes if available.
-    ///
-    /// In-memory implementations can return `Some` to allow zero-copy access.
-    /// Implementations backed by external storage (e.g. Postgres, disk without mmap)
-    /// should return `None` (the default).
-    fn as_slice(&self) -> Option<&[u8]> {
-        None
-    }
 }
 
 #[derive(Debug)]
@@ -118,10 +99,6 @@ impl FileHandle for &'static [u8] {
 
     async fn read_bytes_async(&self, byte_range: Range<usize>) -> io::Result<OwnedBytes> {
         Ok(self.read_bytes(byte_range)?)
-    }
-
-    fn as_slice(&self) -> Option<&[u8]> {
-        Some(self)
     }
 }
 
@@ -258,23 +235,6 @@ impl FileSlice {
         self.data.read_bytes_async(self.range.clone()).await
     }
 
-    /// Reads a single byte without allocating OwnedBytes.
-    pub fn read_byte(&self, offset: usize) -> io::Result<u8> {
-        if let Some(slice) = self.as_slice() {
-            Ok(slice[offset])
-        } else {
-            self.data.read_byte(self.range.start + offset)
-        }
-    }
-
-    /// Returns a direct reference to the underlying bytes if the implementation supports it.
-    ///
-    /// Returns `None` if the underlying storage doesn't support zero-copy access.
-    pub fn as_slice(&self) -> Option<&[u8]> {
-        let all = self.data.as_slice()?;
-        Some(&all[self.range.clone()])
-    }
-
     /// Reads a specific slice of data.
     ///
     /// This is equivalent to running `file_slice.slice(from, to).read_bytes()`.
@@ -360,10 +320,6 @@ impl FileHandle for FileSlice {
     async fn read_bytes_async(&self, byte_range: Range<usize>) -> io::Result<OwnedBytes> {
         self.read_bytes_slice_async(byte_range).await
     }
-
-    fn as_slice(&self) -> Option<&[u8]> {
-        self.as_slice()
-    }
 }
 
 impl HasLen for FileSlice {
@@ -380,10 +336,6 @@ impl FileHandle for OwnedBytes {
 
     async fn read_bytes_async(&self, range: Range<usize>) -> io::Result<OwnedBytes> {
         self.read_bytes(range)
-    }
-
-    fn as_slice(&self) -> Option<&[u8]> {
-        Some(OwnedBytes::as_slice(self))
     }
 }
 

--- a/src/fieldnorm/mod.rs
+++ b/src/fieldnorm/mod.rs
@@ -85,7 +85,7 @@ mod tests {
             assert!(fields_composite.open_read(*FIELD).is_none());
             assert!(fields_composite.open_read(*STR_FIELD).is_none());
             let data = fields_composite.open_read(*TXT_FIELD).unwrap();
-            let fieldnorm_reader = FieldNormReader::open(data);
+            let fieldnorm_reader = FieldNormReader::open(data)?;
             assert_eq!(fieldnorm_reader.fieldnorm(0u32), 0u32);
             assert_eq!(fieldnorm_reader.fieldnorm(1u32), 0u32);
             assert_eq!(fieldnorm_reader.fieldnorm(2u32), 5u32);

--- a/src/fieldnorm/reader.rs
+++ b/src/fieldnorm/reader.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
-use common::HasLen;
-
 use super::{fieldnorm_to_id, id_to_fieldnorm};
-use crate::directory::{CompositeFile, FileSlice};
+use crate::directory::{CompositeFile, FileSlice, OwnedBytes};
 use crate::schema::{Field, Schema};
 use crate::space_usage::PerFieldSpaceUsage;
 use crate::DocId;
@@ -20,6 +18,7 @@ pub struct FieldNormReaders {
 }
 
 impl FieldNormReaders {
+    /// Creates a field norm reader.
     pub fn open(file: FileSlice) -> crate::Result<FieldNormReaders> {
         let data = CompositeFile::open(&file)?;
         Ok(FieldNormReaders {
@@ -30,7 +29,8 @@ impl FieldNormReaders {
     /// Returns the FieldNormReader for a specific field.
     pub fn get_field(&self, field: Field) -> crate::Result<Option<FieldNormReader>> {
         if let Some(file) = self.data.open_read(field) {
-            Ok(Some(FieldNormReader::open(file)))
+            let fieldnorm_reader = FieldNormReader::open(file)?;
+            Ok(Some(fieldnorm_reader))
         } else {
             Ok(None)
         }
@@ -62,8 +62,12 @@ impl From<ReaderImplEnum> for FieldNormReader {
 
 #[derive(Clone)]
 enum ReaderImplEnum {
-    FromFileSlice(FileSlice),
-    Const { num_docs: u32, fieldnorm_id: u8 },
+    FromData(OwnedBytes),
+    Const {
+        num_docs: u32,
+        fieldnorm_id: u8,
+        fieldnorm: u32,
+    },
 }
 
 impl FieldNormReader {
@@ -73,37 +77,60 @@ impl FieldNormReader {
     /// from an array-backed fieldnorm reader.
     pub fn constant(num_docs: u32, fieldnorm: u32) -> FieldNormReader {
         let fieldnorm_id = fieldnorm_to_id(fieldnorm);
+        let fieldnorm = id_to_fieldnorm(fieldnorm_id);
         ReaderImplEnum::Const {
             num_docs,
             fieldnorm_id,
+            fieldnorm,
         }
         .into()
     }
 
-    pub fn open(fieldnorm_file: FileSlice) -> Self {
-        ReaderImplEnum::FromFileSlice(fieldnorm_file).into()
+    /// Opens a field norm reader given its file.
+    pub fn open(fieldnorm_file: FileSlice) -> crate::Result<Self> {
+        let data = fieldnorm_file.read_bytes()?;
+        Ok(FieldNormReader::new(data))
+    }
+
+    fn new(data: OwnedBytes) -> Self {
+        ReaderImplEnum::FromData(data).into()
     }
 
     /// Returns the number of documents in this segment.
     pub fn num_docs(&self) -> u32 {
         match &self.0 {
-            ReaderImplEnum::FromFileSlice(file_slice) => file_slice.len() as u32,
+            ReaderImplEnum::FromData(data) => data.len() as u32,
             ReaderImplEnum::Const { num_docs, .. } => *num_docs,
         }
     }
 
     /// Returns the `fieldnorm` associated with a doc id.
+    /// The fieldnorm is a value approximating the number
+    /// of tokens in a given field of the `doc_id`.
+    ///
+    /// It is imprecise, and equal or lower than
+    /// the actual number of tokens.
+    ///
+    /// The fieldnorm is effectively decoded from the
+    /// `fieldnorm_id` by doing a simple table lookup.
     pub fn fieldnorm(&self, doc_id: DocId) -> u32 {
-        id_to_fieldnorm(self.fieldnorm_id(doc_id))
+        match &self.0 {
+            ReaderImplEnum::FromData(data) => {
+                let fieldnorm_id = data.as_slice()[doc_id as usize];
+                id_to_fieldnorm(fieldnorm_id)
+            }
+            ReaderImplEnum::Const { fieldnorm, .. } => *fieldnorm,
+        }
     }
 
     /// Returns the `fieldnorm_id` associated with a document.
     #[inline]
     pub fn fieldnorm_id(&self, doc_id: DocId) -> u8 {
         match &self.0 {
-            ReaderImplEnum::FromFileSlice(file_slice) => file_slice
-                .read_byte(doc_id as usize)
-                .expect("failed to read fieldnorm byte"),
+            ReaderImplEnum::FromData(data) => {
+                let fieldnorm_id = data.as_slice()[doc_id as usize];
+                fieldnorm_id
+            }
             ReaderImplEnum::Const { fieldnorm_id, .. } => *fieldnorm_id,
         }
     }
@@ -128,7 +155,8 @@ impl FieldNormReader {
             .cloned()
             .map(FieldNormReader::fieldnorm_to_id)
             .collect::<Vec<u8>>();
-        FieldNormReader::open(FileSlice::from(field_norms_id))
+        let field_norms_data = OwnedBytes::new(field_norms_id);
+        FieldNormReader::new(field_norms_data)
     }
 }
 

--- a/src/index/segment_reader.rs
+++ b/src/index/segment_reader.rs
@@ -622,10 +622,11 @@ impl SegmentReader {
     #[inline]
     fn fieldnorm_readers(&self) -> &FieldNormReaders {
         self.fieldnorm_readers.get_or_init(move || {
-            let file = self
-                .open_read(SegmentComponent::FieldNorms)
-                .expect("should be able to open field norms segment component");
-            FieldNormReaders::open(file).expect("should be able to open field norms readers")
+            FieldNormReaders::open(
+                self.open_read(SegmentComponent::FieldNorms)
+                    .expect("should be able to open field norms segment component"),
+            )
+            .expect("should be able to open field norms readers")
         })
     }
 


### PR DESCRIPTION
This reverts commit 7aa40c6d0ad660233297e8a52bc23bb6506db64d so we can do an ordered apply from paradedb.

DO NOT MERGE UNTIL THE MATCHING PARADEDB REVERT MERGES 😊