### PR TITLE
refactor: extract codec selection mechanics

### DIFF
--- a/columnar/src/column/serialize.rs
+++ b/columnar/src/column/serialize.rs
@@ -28,14 +28,11 @@ pub fn serialize_column_mappable_to_u128<T: MonotonicallyMappableToU128>(
 pub fn serialize_column_mappable_to_u64<T: MonotonicallyMappableToU64>(
     column_index: SerializableColumnIndex<'_>,
     column_values: &impl Iterable<T>,
+    codec_types: &[CodecType],
     output: &mut impl Write,
 ) -> io::Result<()> {
     let column_index_num_bytes = serialize_column_index(column_index, output)?;
-    serialize_u64_based_column_values(
-        column_values,
-        &[CodecType::Bitpacked, CodecType::BlockwiseLinear],
-        output,
-    )?;
+    serialize_u64_based_column_values(column_values, codec_types, output)?;
     output.write_all(&column_index_num_bytes.to_le_bytes())?;
     Ok(())
 }

--- a/columnar/src/column_index/multivalued_index.rs
+++ b/columnar/src/column_index/multivalued_index.rs
@@ -381,7 +381,9 @@ mod tests {
         columnar_writer.record_numerical(5, "full", u64::MAX);
 
         let mut wrt: Vec<u8> = Vec::new();
-        columnar_writer.serialize(7, None, &mut wrt).unwrap();
+        columnar_writer
+            .serialize(7, None, &crate::DEFAULT_CODEC_TYPES, &mut wrt)
+            .unwrap();
 
         let reader = ColumnarReader::open(wrt).unwrap();
         // Open the column as u64

--- a/columnar/src/column_index/optional_index/tests.rs
+++ b/columnar/src/column_index/optional_index/tests.rs
@@ -16,7 +16,7 @@ fn test_optional_index_with_num_docs(num_docs: u32) {
     dataframe_writer.record_numerical(100, "score", 80i64);
     let mut buffer: Vec<u8> = Vec::new();
     dataframe_writer
-        .serialize(num_docs, None, &mut buffer)
+        .serialize(num_docs, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
         .unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);

--- a/columnar/src/column_values/mod.rs
+++ b/columnar/src/column_values/mod.rs
@@ -27,7 +27,8 @@ mod monotonic_column;
 pub(crate) use merge::MergedColumnValues;
 pub use stats::ColumnStats;
 pub use u64_based::{
-    ALL_U64_CODEC_TYPES, CodecType, load_u64_based_column_values, serialize_u64_based_column_values,
+    ALL_U64_CODEC_TYPES, CodecType, load_u64_based_column_values,
+    serialize_u64_based_column_values,
 };
 pub use u128_based::{
     CompactSpaceU64Accessor, open_u128_as_compact_u64, open_u128_mapped,

--- a/columnar/src/column_values/mod.rs
+++ b/columnar/src/column_values/mod.rs
@@ -27,8 +27,7 @@ mod monotonic_column;
 pub(crate) use merge::MergedColumnValues;
 pub use stats::ColumnStats;
 pub use u64_based::{
-    ALL_U64_CODEC_TYPES, CodecType, load_u64_based_column_values,
-    serialize_u64_based_column_values,
+    ALL_U64_CODEC_TYPES, CodecType, load_u64_based_column_values, serialize_u64_based_column_values,
 };
 pub use u128_based::{
     CompactSpaceU64Accessor, open_u128_as_compact_u64, open_u128_mapped,

--- a/columnar/src/column_values/u64_based/mod.rs
+++ b/columnar/src/column_values/u64_based/mod.rs
@@ -75,7 +75,9 @@ pub trait ColumnCodec<T: PartialOrd = u64> {
 }
 
 /// Available codecs to use to encode the u64 (via [`MonotonicallyMappableToU64`]) converted data.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
+#[derive(
+    PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy, serde::Serialize, serde::Deserialize,
+)]
 #[repr(u8)]
 pub enum CodecType {
     /// Bitpack all values in the value range. The number of bits is defined by the amplitude
@@ -97,11 +99,13 @@ pub const ALL_U64_CODEC_TYPES: [CodecType; 3] = [
 ];
 
 impl CodecType {
-    fn to_code(self) -> u8 {
+    /// Returns the u8 code for this codec type.
+    pub fn to_code(self) -> u8 {
         self as u8
     }
 
-    fn try_from_code(code: u8) -> Option<CodecType> {
+    /// Attempts to convert a u8 code to a `CodecType`. Returns `None` for unknown codes.
+    pub fn try_from_code(code: u8) -> Option<CodecType> {
         match code {
             0u8 => Some(CodecType::Bitpacked),
             1u8 => Some(CodecType::Linear),

--- a/columnar/src/column_values/u64_based/tests.rs
+++ b/columnar/src/column_values/u64_based/tests.rs
@@ -175,6 +175,7 @@ proptest! {
     fn test_proptest_small_blockwise_linear(data in proptest::collection::vec(num_strategy(), 1..10)) {
         create_and_validate::<BlockwiseLinearCodec>(&data, "proptest multilinearinterpol");
     }
+
 }
 
 #[test]
@@ -202,6 +203,7 @@ proptest! {
     fn test_proptest_large_blockwise_linear(data in proptest::collection::vec(num_strategy(), 1..6000)) {
         create_and_validate::<BlockwiseLinearCodec>(&data, "proptest multilinearinterpol");
     }
+
 }
 
 fn num_strategy() -> impl Strategy<Value = u64> {
@@ -258,7 +260,6 @@ fn test_codec_interpolation() {
 fn test_codec_multi_interpolation() {
     test_codec::<BlockwiseLinearCodec>();
 }
-
 use super::*;
 
 fn estimate<C: ColumnCodec>(vals: &[u64]) -> Option<f32> {

--- a/columnar/src/columnar/merge/merge_dict_column.rs
+++ b/columnar/src/columnar/merge/merge_dict_column.rs
@@ -6,6 +6,7 @@ use sstable::{SSTable, Streamer, TermOrdinal, VoidSSTable};
 use super::term_merger::{TermMerger, TermsWithSegmentOrd};
 use crate::column::serialize_column_mappable_to_u64;
 use crate::column_index::SerializableColumnIndex;
+use crate::column_values::CodecType;
 use crate::iterable::Iterable;
 use crate::{BytesColumn, MergeRowOrder, ShuffleMergeOrder};
 
@@ -15,6 +16,7 @@ pub fn merge_bytes_or_str_column(
     column_index: SerializableColumnIndex<'_>,
     bytes_columns: &[Option<BytesColumn>],
     merge_row_order: &MergeRowOrder,
+    codec_types: &[CodecType],
     output: &mut impl Write,
 ) -> io::Result<()> {
     // Serialize dict and generate mapping for values
@@ -28,7 +30,12 @@ pub fn merge_bytes_or_str_column(
         term_ord_mapping: &term_ord_mapping,
         merge_row_order,
     };
-    serialize_column_mappable_to_u64(column_index, &remapped_term_ordinals_values, output)?;
+    serialize_column_mappable_to_u64(
+        column_index,
+        &remapped_term_ordinals_values,
+        codec_types,
+        output,
+    )?;
     output.write_all(&dictionary_num_bytes.to_le_bytes())?;
     Ok(())
 }

--- a/columnar/src/columnar/merge/mod.rs
+++ b/columnar/src/columnar/merge/mod.rs
@@ -13,7 +13,7 @@ pub use merge_mapping::{MergeRowOrder, ShuffleMergeOrder, StackMergeOrder};
 
 use super::writer::ColumnarSerializer;
 use crate::column::{serialize_column_mappable_to_u64, serialize_column_mappable_to_u128};
-use crate::column_values::MergedColumnValues;
+use crate::column_values::{CodecType, MergedColumnValues};
 use crate::columnar::ColumnarReader;
 use crate::columnar::merge::merge_dict_column::merge_bytes_or_str_column;
 use crate::columnar::writer::CompatibleNumericalTypes;
@@ -79,6 +79,7 @@ pub fn merge_columnar(
     columnar_readers: &[&ColumnarReader],
     required_columns: &[(String, ColumnType)],
     merge_row_order: MergeRowOrder,
+    codec_types: &[CodecType],
     output: &mut impl io::Write,
     cancel: impl Fn() -> bool,
 ) -> io::Result<()> {
@@ -113,6 +114,7 @@ pub fn merge_columnar(
             &num_docs_per_columnar,
             columns,
             &merge_row_order,
+            codec_types,
             &mut column_serializer,
         )?;
         column_serializer.finalize()?;
@@ -138,6 +140,7 @@ fn merge_column(
     num_docs_per_column: &[u32],
     columns_to_merge: Vec<Option<DynamicColumn>>,
     merge_row_order: &MergeRowOrder,
+    codec_types: &[CodecType],
     wrt: &mut impl io::Write,
 ) -> io::Result<()> {
     match column_type {
@@ -170,7 +173,12 @@ fn merge_column(
                 column_values: &column_values[..],
                 merge_row_order,
             };
-            serialize_column_mappable_to_u64(merged_column_index, &merge_column_values, wrt)?;
+            serialize_column_mappable_to_u64(
+                merged_column_index,
+                &merge_column_values,
+                codec_types,
+                wrt,
+            )?;
         }
         ColumnType::IpAddr => {
             let mut column_indexes: Vec<ColumnIndex> = Vec::with_capacity(columns_to_merge.len());
@@ -224,7 +232,13 @@ fn merge_column(
             }
             let merged_column_index =
                 crate::column_index::merge_column_index(&column_indexes[..], merge_row_order);
-            merge_bytes_or_str_column(merged_column_index, &bytes_columns, merge_row_order, wrt)?;
+            merge_bytes_or_str_column(
+                merged_column_index,
+                &bytes_columns,
+                merge_row_order,
+                codec_types,
+                wrt,
+            )?;
         }
     }
     Ok(())

--- a/columnar/src/columnar/merge/tests.rs
+++ b/columnar/src/columnar/merge/tests.rs
@@ -17,7 +17,12 @@ fn make_columnar<T: Into<NumericalValue> + HasAssociatedColumnType + Copy>(
     }
     let mut buffer: Vec<u8> = Vec::new();
     dataframe_writer
-        .serialize(vals.len() as RowId, None, &mut buffer)
+        .serialize(
+            vals.len() as RowId,
+            None,
+            &crate::DEFAULT_CODEC_TYPES,
+            &mut buffer,
+        )
         .unwrap();
     ColumnarReader::open(buffer).unwrap()
 }
@@ -144,7 +149,7 @@ fn make_numerical_columnar_multiple_columns(
         .unwrap_or(0u32);
     let mut buffer: Vec<u8> = Vec::new();
     dataframe_writer
-        .serialize(num_rows, None, &mut buffer)
+        .serialize(num_rows, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
         .unwrap();
     ColumnarReader::open(buffer).unwrap()
 }
@@ -169,7 +174,7 @@ fn make_byte_columnar_multiple_columns(
     }
     let mut buffer: Vec<u8> = Vec::new();
     dataframe_writer
-        .serialize(num_rows, None, &mut buffer)
+        .serialize(num_rows, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
         .unwrap();
     ColumnarReader::open(buffer).unwrap()
 }
@@ -190,7 +195,7 @@ fn make_text_columnar_multiple_columns(columns: &[(&str, &[&[&str]])]) -> Column
         .unwrap_or(0u32);
     let mut buffer: Vec<u8> = Vec::new();
     dataframe_writer
-        .serialize(num_rows, None, &mut buffer)
+        .serialize(num_rows, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
         .unwrap();
     ColumnarReader::open(buffer).unwrap()
 }
@@ -210,6 +215,7 @@ fn test_merge_columnar_numbers() {
         columnars,
         &[],
         MergeRowOrder::Stack(stack_merge_order),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut buffer,
         || false,
     )
@@ -239,6 +245,7 @@ fn test_merge_columnar_texts() {
         columnars,
         &[],
         MergeRowOrder::Stack(stack_merge_order),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut buffer,
         || false,
     )
@@ -289,6 +296,7 @@ fn test_merge_columnar_byte() {
         columnars,
         &[],
         MergeRowOrder::Stack(stack_merge_order),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut buffer,
         || false,
     )
@@ -346,6 +354,7 @@ fn test_merge_columnar_byte_with_missing() {
         columnars,
         &[],
         MergeRowOrder::Stack(stack_merge_order),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut buffer,
         || false,
     )
@@ -399,6 +408,7 @@ fn test_merge_columnar_different_types() {
         columnars,
         &[],
         MergeRowOrder::Stack(stack_merge_order),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut buffer,
         || false,
     )
@@ -465,6 +475,7 @@ fn test_merge_columnar_different_empty_cardinality() {
         columnars,
         &[],
         MergeRowOrder::Stack(stack_merge_order),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut buffer,
         || false,
     )
@@ -556,7 +567,14 @@ fn build_columnar(spec: &ColumnarSpec) -> ColumnarReader {
     }
 
     let mut buffer = Vec::new();
-    writer.serialize(max_row_id + 1, None, &mut buffer).unwrap();
+    writer
+        .serialize(
+            max_row_id + 1,
+            None,
+            &crate::DEFAULT_CODEC_TYPES,
+            &mut buffer,
+        )
+        .unwrap();
     ColumnarReader::open(buffer).unwrap()
 }
 
@@ -576,6 +594,7 @@ proptest! {
             &columnar_refs,
             &[],
             MergeRowOrder::Stack(stack_merge_order),
+            &crate::DEFAULT_CODEC_TYPES,
             &mut out,
             || false,
         ).unwrap();
@@ -594,6 +613,7 @@ proptest! {
             &columnar_refs,
             &[],
             MergeRowOrder::Stack(stack_merge_order),
+            &crate::DEFAULT_CODEC_TYPES,
             &mut out,
             || false,
         ).unwrap();

--- a/columnar/src/columnar/reader/mod.rs
+++ b/columnar/src/columnar/reader/mod.rs
@@ -226,7 +226,9 @@ mod tests {
         columnar_writer.record_column_type("col1", ColumnType::Str, false);
         columnar_writer.record_column_type("col2", ColumnType::U64, false);
         let mut buffer = Vec::new();
-        columnar_writer.serialize(1, None, &mut buffer).unwrap();
+        columnar_writer
+            .serialize(1, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+            .unwrap();
         let columnar = ColumnarReader::open(buffer).unwrap();
         let columns = columnar.list_columns().unwrap();
         assert_eq!(columns.len(), 2);
@@ -242,7 +244,9 @@ mod tests {
         columnar_writer.record_column_type("count", ColumnType::U64, false);
         columnar_writer.record_numerical(1, "count", 1u64);
         let mut buffer = Vec::new();
-        columnar_writer.serialize(2, None, &mut buffer).unwrap();
+        columnar_writer
+            .serialize(2, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+            .unwrap();
         let columnar = ColumnarReader::open(buffer).unwrap();
         let columns = columnar.list_columns().unwrap();
         assert_eq!(columns.len(), 1);
@@ -256,7 +260,9 @@ mod tests {
         columnar_writer.record_column_type("col", ColumnType::U64, false);
         columnar_writer.record_numerical(1, "col", 1u64);
         let mut buffer = Vec::new();
-        columnar_writer.serialize(2, None, &mut buffer).unwrap();
+        columnar_writer
+            .serialize(2, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+            .unwrap();
         let columnar = ColumnarReader::open(buffer).unwrap();
         {
             let columns = columnar.read_columns("col").unwrap();
@@ -285,7 +291,9 @@ mod tests {
         columnar_writer.record_str(1, "col1", "hello");
         columnar_writer.record_str(0, "col2", "hello");
         let mut buffer = Vec::new();
-        columnar_writer.serialize(2, None, &mut buffer).unwrap();
+        columnar_writer
+            .serialize(2, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+            .unwrap();
 
         let columnar = ColumnarReader::open(buffer).unwrap();
         {

--- a/columnar/src/columnar/writer/mod.rs
+++ b/columnar/src/columnar/writer/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use serializer::ColumnarSerializer;
 use stacker::{Addr, ArenaHashMap, MemoryArena};
 
 use crate::column_index::{SerializableColumnIndex, SerializableOptionalIndex};
-use crate::column_values::{MonotonicallyMappableToU64, MonotonicallyMappableToU128};
+use crate::column_values::{CodecType, MonotonicallyMappableToU64, MonotonicallyMappableToU128};
 use crate::columnar::column_type::ColumnType;
 use crate::columnar::writer::column_writers::{
     ColumnWriter, NumericalColumnWriter, StrOrBytesColumnWriter,
@@ -44,7 +44,7 @@ struct SpareBuffers {
 /// columnar_writer.record_str(1u32 /* doc id */, "product_name", "Apple");
 /// columnar_writer.record_numerical(0u32 /* doc id */, "price", 10.5f64); //< uh oh we ended up mixing integer and floats.
 /// let mut wrt: Vec<u8> =  Vec::new();
-/// columnar_writer.serialize(2u32, None, &mut wrt).unwrap();
+/// columnar_writer.serialize(2u32, None, &tantivy_columnar::DEFAULT_CODEC_TYPES, &mut wrt).unwrap();
 /// ```
 #[derive(Default)]
 pub struct ColumnarWriter {
@@ -319,6 +319,7 @@ impl ColumnarWriter {
         &mut self,
         num_docs: RowId,
         old_to_new_row_ids: Option<&[RowId]>,
+        codec_types: &[CodecType],
         wrt: &mut dyn io::Write,
     ) -> io::Result<()> {
         let mut serializer = ColumnarSerializer::new(wrt);
@@ -383,6 +384,7 @@ impl ColumnarWriter {
                             &mut symbol_byte_buffer,
                         ),
                         buffers,
+                        codec_types,
                         &mut column_serializer,
                     )?;
                     column_serializer.finalize()?;
@@ -431,6 +433,7 @@ impl ColumnarWriter {
                         ),
                         buffers,
                         &self.arena,
+                        codec_types,
                         &mut column_serializer,
                     )?;
                     column_serializer.finalize()?;
@@ -452,6 +455,7 @@ impl ColumnarWriter {
                             &mut symbol_byte_buffer,
                         ),
                         buffers,
+                        codec_types,
                         &mut column_serializer,
                     )?;
                     column_serializer.finalize()?;
@@ -471,6 +475,7 @@ impl ColumnarWriter {
                             &mut symbol_byte_buffer,
                         ),
                         buffers,
+                        codec_types,
                         &mut column_serializer,
                     )?;
                     column_serializer.finalize()?;
@@ -543,6 +548,7 @@ fn serialize_bytes_or_str_column(
     operation_it: impl Iterator<Item = ColumnOperation<UnorderedId>>,
     buffers: &mut SpareBuffers,
     arena: &MemoryArena,
+    codec_types: &[CodecType],
     wrt: impl io::Write,
 ) -> io::Result<()> {
     let SpareBuffers {
@@ -572,6 +578,7 @@ fn serialize_bytes_or_str_column(
         sort_values_within_row,
         value_index_builders,
         u64_values,
+        codec_types,
         &mut wrt,
     )?;
     wrt.write_all(&dictionary_num_bytes.to_le_bytes()[..])?;
@@ -584,6 +591,7 @@ fn serialize_numerical_column(
     numerical_type: NumericalType,
     op_iterator: impl Iterator<Item = ColumnOperation<NumericalValue>>,
     buffers: &mut SpareBuffers,
+    codec_types: &[CodecType],
     wrt: &mut impl io::Write,
 ) -> io::Result<()> {
     let SpareBuffers {
@@ -600,6 +608,7 @@ fn serialize_numerical_column(
                 false,
                 value_index_builders,
                 u64_values,
+                codec_types,
                 wrt,
             )?;
         }
@@ -611,6 +620,7 @@ fn serialize_numerical_column(
                 false,
                 value_index_builders,
                 u64_values,
+                codec_types,
                 wrt,
             )?;
         }
@@ -622,6 +632,7 @@ fn serialize_numerical_column(
                 false,
                 value_index_builders,
                 u64_values,
+                codec_types,
                 wrt,
             )?;
         }
@@ -634,6 +645,7 @@ fn serialize_bool_column(
     num_docs: RowId,
     column_operations_it: impl Iterator<Item = ColumnOperation<bool>>,
     buffers: &mut SpareBuffers,
+    codec_types: &[CodecType],
     wrt: &mut impl io::Write,
 ) -> io::Result<()> {
     let SpareBuffers {
@@ -651,6 +663,7 @@ fn serialize_bool_column(
         false,
         value_index_builders,
         u64_values,
+        codec_types,
         wrt,
     )?;
     Ok(())
@@ -731,6 +744,7 @@ fn send_to_serialize_column_mappable_to_u64(
     sort_values_within_row: bool,
     value_index_builders: &mut PreallocatedIndexBuilders,
     values: &mut Vec<u64>,
+    codec_types: &[CodecType],
     mut wrt: impl io::Write,
 ) -> io::Result<()> {
     values.clear();
@@ -768,6 +782,7 @@ fn send_to_serialize_column_mappable_to_u64(
     crate::column::serialize_column_mappable_to_u64(
         serializable_column_index,
         &&values[..],
+        codec_types,
         &mut wrt,
     )?;
     Ok(())

--- a/columnar/src/compat_tests.rs
+++ b/columnar/src/compat_tests.rs
@@ -27,7 +27,9 @@ fn generate_columnar(num_docs: u32, value_offset: u64) -> Vec<u8> {
     }
 
     let mut wrt: Vec<u8> = Vec::new();
-    columnar_writer.serialize(num_docs, None, &mut wrt).unwrap();
+    columnar_writer
+        .serialize(num_docs, None, &crate::DEFAULT_CODEC_TYPES, &mut wrt)
+        .unwrap();
 
     wrt
 }
@@ -75,6 +77,7 @@ fn test_format(path: &str) {
         &columnar_readers,
         &[],
         merge_row_order.into(),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut out,
         || false,
     )

--- a/columnar/src/lib.rs
+++ b/columnar/src/lib.rs
@@ -39,8 +39,12 @@ pub use block_accessor::ColumnBlockAccessor;
 pub use column::{BytesColumn, Column, StrColumn};
 pub use column_index::ColumnIndex;
 pub use column_values::{
-    ColumnValues, EmptyColumnValues, MonotonicallyMappableToU64, MonotonicallyMappableToU128,
+    CodecType, ColumnStats, ColumnValues, EmptyColumnValues, MonotonicallyMappableToU64,
+    MonotonicallyMappableToU128,
 };
+
+/// Default codec types used for u64-based column serialization.
+pub const DEFAULT_CODEC_TYPES: [CodecType; 2] = [CodecType::Bitpacked, CodecType::BlockwiseLinear];
 pub use columnar::{
     CURRENT_VERSION, ColumnType, ColumnarReader, ColumnarWriter, HasAssociatedColumnType,
     MergeRowOrder, ShuffleMergeOrder, StackMergeOrder, Version, compute_merged_term_ord_mapping,

--- a/columnar/src/tests.rs
+++ b/columnar/src/tests.rs
@@ -21,7 +21,9 @@ fn test_dataframe_writer_str() {
     dataframe_writer.record_str(1u32, "my_string", "hello");
     dataframe_writer.record_str(3u32, "my_string", "helloeee");
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(5, None, &mut buffer).unwrap();
+    dataframe_writer
+        .serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("my_string").unwrap();
@@ -35,7 +37,9 @@ fn test_dataframe_writer_bytes() {
     dataframe_writer.record_bytes(1u32, "my_string", b"hello");
     dataframe_writer.record_bytes(3u32, "my_string", b"helloeee");
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(5, None, &mut buffer).unwrap();
+    dataframe_writer
+        .serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("my_string").unwrap();
@@ -49,7 +53,9 @@ fn test_dataframe_writer_bool() {
     dataframe_writer.record_bool(1u32, "bool.value", false);
     dataframe_writer.record_bool(3u32, "bool.value", true);
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(5, None, &mut buffer).unwrap();
+    dataframe_writer
+        .serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("bool.value").unwrap();
@@ -74,7 +80,9 @@ fn test_dataframe_writer_u64_multivalued() {
     dataframe_writer.record_numerical(6u32, "divisor", 2u64);
     dataframe_writer.record_numerical(6u32, "divisor", 3u64);
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(7, None, &mut buffer).unwrap();
+    dataframe_writer
+        .serialize(7, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("divisor").unwrap();
@@ -97,7 +105,9 @@ fn test_dataframe_writer_ip_addr() {
     dataframe_writer.record_ip_addr(1, "ip_addr", Ipv6Addr::from_u128(1001));
     dataframe_writer.record_ip_addr(3, "ip_addr", Ipv6Addr::from_u128(1050));
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(5, None, &mut buffer).unwrap();
+    dataframe_writer
+        .serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("ip_addr").unwrap();
@@ -128,7 +138,9 @@ fn test_dataframe_writer_numerical() {
     dataframe_writer.record_numerical(2u32, "srical.value", NumericalValue::U64(13u64));
     dataframe_writer.record_numerical(4u32, "srical.value", NumericalValue::U64(15u64));
     let mut buffer: Vec<u8> = Vec::new();
-    dataframe_writer.serialize(6, None, &mut buffer).unwrap();
+    dataframe_writer
+        .serialize(6, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .unwrap();
     let columnar = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("srical.value").unwrap();
@@ -201,7 +213,9 @@ fn test_dictionary_encoded_str() {
     columnar_writer.record_str(3, "my.column", "c");
     columnar_writer.record_str(3, "my.column2", "different_column!");
     columnar_writer.record_str(4, "my.column", "b");
-    columnar_writer.serialize(5, None, &mut buffer).unwrap();
+    columnar_writer
+        .serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .unwrap();
     let columnar_reader = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar_reader.num_columns(), 2);
     let col_handles = columnar_reader.read_columns("my.column").unwrap();
@@ -235,7 +249,9 @@ fn test_dictionary_encoded_bytes() {
     columnar_writer.record_bytes(3, "my.column", b"c");
     columnar_writer.record_bytes(3, "my.column2", b"different_column!");
     columnar_writer.record_bytes(4, "my.column", b"b");
-    columnar_writer.serialize(5, None, &mut buffer).unwrap();
+    columnar_writer
+        .serialize(5, None, &crate::DEFAULT_CODEC_TYPES, &mut buffer)
+        .unwrap();
     let columnar_reader = ColumnarReader::open(buffer).unwrap();
     assert_eq!(columnar_reader.num_columns(), 2);
     let col_handles = columnar_reader.read_columns("my.column").unwrap();
@@ -504,7 +520,12 @@ fn build_columnar_with_mapping(
         }
     }
     columnar_writer
-        .serialize(num_docs, old_to_new_row_ids_opt, &mut buffer)
+        .serialize(
+            num_docs,
+            old_to_new_row_ids_opt,
+            &crate::DEFAULT_CODEC_TYPES,
+            &mut buffer,
+        )
         .unwrap();
 
     ColumnarReader::open(buffer).unwrap()
@@ -832,7 +853,7 @@ proptest! {
         let columnar_readers_arr: Vec<&ColumnarReader> = columnar_readers.iter().collect();
         let mut output: Vec<u8> = Vec::new();
         let stack_merge_order = StackMergeOrder::stack(&columnar_readers_arr[..]).into();
-        crate::merge_columnar(&columnar_readers_arr[..], &[], stack_merge_order, &mut output, || false,).unwrap();
+        crate::merge_columnar(&columnar_readers_arr[..], &[], stack_merge_order, &crate::DEFAULT_CODEC_TYPES, &mut output, || false,).unwrap();
         let merged_columnar = ColumnarReader::open(output).unwrap();
         let concat_rows: Vec<Vec<(&'static str, ColumnValue)>> = columnar_docs.iter().flatten().cloned().collect();
         let expected_merged_columnar = build_columnar(&concat_rows[..]);
@@ -855,6 +876,7 @@ fn test_columnar_merging_empty_columnar() {
         &columnar_readers_arr[..],
         &[],
         crate::MergeRowOrder::Stack(stack_merge_order),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut output,
         || false,
     )
@@ -893,6 +915,7 @@ fn test_columnar_merging_number_columns() {
         &columnar_readers_arr[..],
         &[],
         crate::MergeRowOrder::Stack(stack_merge_order),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut output,
         || false,
     )
@@ -967,6 +990,7 @@ fn test_columnar_merge_and_remap(
         &columnar_readers_ref[..],
         &[],
         shuffle_merge_order.into(),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut output,
         || false,
     )
@@ -1010,6 +1034,7 @@ fn test_columnar_merge_empty() {
         &[&columnar_reader_1, &columnar_reader_2],
         &[],
         shuffle_merge_order.into(),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut output,
         || false,
     )
@@ -1037,6 +1062,7 @@ fn test_columnar_merge_single_str_column() {
         &[&columnar_reader_1, &columnar_reader_2],
         &[],
         shuffle_merge_order.into(),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut output,
         || false,
     )
@@ -1070,6 +1096,7 @@ fn test_delete_decrease_cardinality() {
         &[&columnar_reader_1, &columnar_reader_2],
         &[],
         shuffle_merge_order.into(),
+        &crate::DEFAULT_CODEC_TYPES,
         &mut output,
         || false,
     )

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -127,7 +127,9 @@ mod tests {
             fast_field_writers
                 .add_document(&doc!(*FIELD=>2u64))
                 .unwrap();
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -178,7 +180,9 @@ mod tests {
             fast_field_writers
                 .add_document(&doc!(*FIELD=>215u64))
                 .unwrap();
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -211,7 +215,9 @@ mod tests {
                     .add_document(&doc!(*FIELD=>100_000u64))
                     .unwrap();
             }
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -243,7 +249,9 @@ mod tests {
                     .add_document(&doc!(*FIELD=>5_000_000_000_000_000_000u64 + doc_id))
                     .unwrap();
             }
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -276,7 +284,9 @@ mod tests {
                 doc.add_i64(i64_field, i);
                 fast_field_writers.add_document(&doc).unwrap();
             }
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -315,7 +325,9 @@ mod tests {
             let mut fast_field_writers = FastFieldsWriter::from_schema(&schema).unwrap();
             let doc = TantivyDocument::default();
             fast_field_writers.add_document(&doc).unwrap();
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
 
@@ -348,7 +360,9 @@ mod tests {
             let mut fast_field_writers = FastFieldsWriter::from_schema(&schema).unwrap();
             let doc = TantivyDocument::default();
             fast_field_writers.add_document(&doc).unwrap();
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
 
@@ -385,7 +399,9 @@ mod tests {
             for &x in &permutation {
                 fast_field_writers.add_document(&doc!(*FIELD=>x)).unwrap();
             }
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -770,7 +786,9 @@ mod tests {
             fast_field_writers
                 .add_document(&doc!(field=>false))
                 .unwrap();
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -802,7 +820,9 @@ mod tests {
                     .add_document(&doc!(field=>false))
                     .unwrap();
             }
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -827,7 +847,9 @@ mod tests {
             let mut fast_field_writers = FastFieldsWriter::from_schema(&schema).unwrap();
             let doc = TantivyDocument::default();
             fast_field_writers.add_document(&doc).unwrap();
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
@@ -855,7 +877,9 @@ mod tests {
             for doc in docs {
                 fast_field_writers.add_document(doc).unwrap();
             }
-            fast_field_writers.serialize(&mut write, None).unwrap();
+            fast_field_writers
+                .serialize(&columnar::DEFAULT_CODEC_TYPES, &mut write, None)
+                .unwrap();
             write.terminate().unwrap();
         }
         Ok(directory)

--- a/src/fastfield/writer.rs
+++ b/src/fastfield/writer.rs
@@ -235,6 +235,7 @@ impl FastFieldsWriter {
     /// order to the fast field serializer.
     pub fn serialize(
         mut self,
+        codec_types: &[columnar::CodecType],
         wrt: &mut dyn io::Write,
         doc_id_map_opt: Option<&DocIdMapping>,
     ) -> io::Result<()> {
@@ -242,7 +243,7 @@ impl FastFieldsWriter {
         let old_to_new_row_ids =
             doc_id_map_opt.map(|doc_id_mapping| doc_id_mapping.old_to_new_ids());
         self.columnar_writer
-            .serialize(num_docs, old_to_new_row_ids, wrt)?;
+            .serialize(num_docs, old_to_new_row_ids, codec_types, wrt)?;
         Ok(())
     }
 }
@@ -392,7 +393,12 @@ mod tests {
         }
         let mut buffer = Vec::new();
         columnar_writer
-            .serialize(json_docs.len() as DocId, None, &mut buffer)
+            .serialize(
+                json_docs.len() as DocId,
+                None,
+                &columnar::DEFAULT_CODEC_TYPES,
+                &mut buffer,
+            )
             .unwrap();
         ColumnarReader::open(buffer).unwrap()
     }

--- a/src/index/index_meta.rs
+++ b/src/index/index_meta.rs
@@ -310,11 +310,23 @@ pub struct IndexSettings {
     #[serde(default = "default_docstore_blocksize")]
     /// The size of each block that will be compressed and written to disk
     pub docstore_blocksize: usize,
+    /// Codec types for u64-based column serialization.
+    #[serde(default = "default_codec_types")]
+    #[serde(skip_serializing_if = "is_default_codec_types")]
+    pub codec_types: Vec<columnar::CodecType>,
 }
 
 /// Must be a function to be compatible with serde defaults
 fn default_docstore_blocksize() -> usize {
     16_384
+}
+
+fn default_codec_types() -> Vec<columnar::CodecType> {
+    columnar::DEFAULT_CODEC_TYPES.to_vec()
+}
+
+fn is_default_codec_types(types: &[columnar::CodecType]) -> bool {
+    types == columnar::DEFAULT_CODEC_TYPES
 }
 
 impl Default for IndexSettings {
@@ -324,7 +336,15 @@ impl Default for IndexSettings {
             docstore_compression: Compressor::default(),
             docstore_blocksize: default_docstore_blocksize(),
             docstore_compress_dedicated_thread: true,
+            codec_types: default_codec_types(),
         }
+    }
+}
+
+impl IndexSettings {
+    /// Returns the codec types to use for u64-based column serialization.
+    pub fn columnar_codec_types(&self) -> &[columnar::CodecType] {
+        &self.codec_types
     }
 }
 
@@ -513,6 +533,7 @@ mod tests {
                 }),
                 docstore_blocksize: 1_000_000,
                 docstore_compress_dedicated_thread: true,
+                ..IndexSettings::default()
             },
             segments: Vec::new(),
             schema,
@@ -579,7 +600,8 @@ mod tests {
                 sort_by_field: None,
                 docstore_compression: Compressor::default(),
                 docstore_compress_dedicated_thread: true,
-                docstore_blocksize: 16_384
+                docstore_blocksize: 16_384,
+                codec_types: columnar::DEFAULT_CODEC_TYPES.to_vec(),
             }
         );
         {
@@ -610,5 +632,48 @@ mod tests {
                 serde_json::from_value(index_settings_json).unwrap();
             assert_eq!(index_settings_deser, index_settings);
         }
+    }
+
+    #[test]
+    fn test_codec_types_settings() {
+        use columnar::CodecType;
+
+        // Empty codec_types = default (V1)
+        let settings = IndexSettings::default();
+        assert_eq!(
+            settings.columnar_codec_types(),
+            &[CodecType::Bitpacked, CodecType::BlockwiseLinear]
+        );
+
+        // Explicit codec_types round-trips through JSON
+        let settings = IndexSettings {
+            codec_types: vec![CodecType::Bitpacked, CodecType::Linear],
+            ..IndexSettings::default()
+        };
+        let json = serde_json::to_value(&settings).unwrap();
+        assert_eq!(
+            json["codec_types"],
+            serde_json::json!(["Bitpacked", "Linear"])
+        );
+        let deser: IndexSettings = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            deser.codec_types,
+            vec![CodecType::Bitpacked, CodecType::Linear]
+        );
+        assert_eq!(
+            deser.columnar_codec_types(),
+            &[CodecType::Bitpacked, CodecType::Linear]
+        );
+
+        // Missing codec_types in JSON = default (V1)
+        let json = serde_json::json!({
+            "docstore_compression": "none",
+            "docstore_blocksize": 16384
+        });
+        let deser: IndexSettings = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            deser.columnar_codec_types(),
+            &[CodecType::Bitpacked, CodecType::BlockwiseLinear]
+        );
     }
 }

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -374,6 +374,7 @@ impl IndexMerger {
             &columnars[..],
             &required_columns,
             merge_row_order,
+            &self.index_settings.columnar_codec_types(),
             fast_field_wrt,
             || self.cancel.wants_cancel(),
         )?;
@@ -2265,5 +2266,55 @@ mod tests {
         // this is the first time I write a unit test for a constant.
         assert!(((super::MAX_DOC_LIMIT - 1) as i32) >= 0);
         assert!((super::MAX_DOC_LIMIT as i32) < 0);
+    }
+
+    #[test]
+    fn test_merge_respects_codec_types_setting() -> crate::Result<()> {
+        use columnar::CodecType;
+
+        use crate::schema::Schema;
+        use crate::IndexSettings;
+
+        // Create index with explicit codec setting
+        let mut schema_builder = Schema::builder();
+        let u64_field = schema_builder.add_u64_field("val", FAST);
+        let schema = schema_builder.build();
+        let settings = IndexSettings {
+            codec_types: vec![CodecType::Bitpacked, CodecType::Linear],
+            ..IndexSettings::default()
+        };
+        let index = Index::builder()
+            .schema(schema)
+            .settings(settings)
+            .create_in_ram()?;
+
+        // Write two segments
+        let mut writer = index.writer_for_tests()?;
+        for i in 0u64..100 {
+            writer.add_document(doc!(u64_field => i))?;
+        }
+        writer.commit()?;
+        for i in 100u64..200 {
+            writer.add_document(doc!(u64_field => i))?;
+        }
+        writer.commit()?;
+
+        // Verify the setting is persisted
+        assert_eq!(
+            index.settings().codec_types,
+            vec![CodecType::Bitpacked, CodecType::Linear]
+        );
+
+        // Merge the two segments
+        let segment_ids: Vec<_> = index.searchable_segment_ids()?;
+        assert_eq!(segment_ids.len(), 2);
+        writer.merge_foreground(&segment_ids, true)?;
+
+        // Verify merge produced a single segment and data is intact
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        assert_eq!(searcher.num_docs(), 200);
+
+        Ok(())
     }
 }

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -75,6 +75,7 @@ pub struct SegmentWriter {
     term_buffer: IndexingTerm,
     schema: Schema,
     ignore_store: bool,
+    columnar_codec_types: Vec<columnar::CodecType>,
 }
 
 impl SegmentWriter {
@@ -96,6 +97,7 @@ impl SegmentWriter {
         let tokenizer_manager = segment.index().tokenizers().clone();
         let tokenizer_manager_fast_field = segment.index().fast_field_tokenizer().clone();
         let table_size = compute_initial_table_size(memory_budget_in_bytes)?;
+        let columnar_codec_types = segment.index().settings().columnar_codec_types().to_vec();
         let segment_serializer = SegmentSerializer::for_segment(segment, false)?;
         let per_field_postings_writers = PerFieldPostingsWriter::for_schema(&schema);
         let per_field_text_analyzers = schema
@@ -137,6 +139,7 @@ impl SegmentWriter {
             term_buffer: IndexingTerm::with_capacity(16),
             schema,
             ignore_store,
+            columnar_codec_types,
         })
     }
 
@@ -164,6 +167,7 @@ impl SegmentWriter {
             self.segment_serializer,
             mapping.as_ref(),
             self.ignore_store,
+            &self.columnar_codec_types,
         )?;
         let doc_opstamps = remap_doc_opstamps(self.doc_opstamps, mapping.as_ref());
         Ok(doc_opstamps)
@@ -429,6 +433,7 @@ fn remap_and_write(
     mut serializer: SegmentSerializer,
     doc_id_map: Option<&DocIdMapping>,
     ignore_store: bool,
+    columnar_codec_types: &[columnar::CodecType],
 ) -> crate::Result<()> {
     debug!("remap-and-write");
     if let Some(fieldnorms_serializer) = serializer.extract_fieldnorms_serializer() {
@@ -447,7 +452,11 @@ fn remap_and_write(
         serializer.get_postings_serializer(),
     )?;
     debug!("fastfield-serialize");
-    fast_field_writers.serialize(serializer.get_fast_field_write(), doc_id_map)?;
+    fast_field_writers.serialize(
+        columnar_codec_types,
+        serializer.get_fast_field_write(),
+        doc_id_map,
+    )?;
 
     // finalize temp docstore and create version, which reflects the doc_id_map
     if !ignore_store {


### PR DESCRIPTION
Add the ability to configure which columnar codecs are used via IndexSettings, and thread that configuration through serialization, segment writing, and merge paths.