### PR TITLE
Lazy fieldnorm reader via FileSlice

### DIFF
--- a/common/src/file_slice.rs
+++ b/common/src/file_slice.rs
@@ -261,9 +261,10 @@ impl FileSlice {
     /// Reads a single byte without allocating OwnedBytes.
     pub fn read_byte(&self, offset: usize) -> io::Result<u8> {
         if let Some(slice) = self.as_slice() {
-            slice.get(offset).copied().ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidInput, "offset out of bounds")
-            })
+            slice
+                .get(offset)
+                .copied()
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "offset out of bounds"))
         } else {
             self.data.read_byte(self.range.start + offset)
         }

--- a/common/src/file_slice.rs
+++ b/common/src/file_slice.rs
@@ -261,7 +261,9 @@ impl FileSlice {
     /// Reads a single byte without allocating OwnedBytes.
     pub fn read_byte(&self, offset: usize) -> io::Result<u8> {
         if let Some(slice) = self.as_slice() {
-            Ok(slice[offset])
+            slice.get(offset).copied().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "offset out of bounds")
+            })
         } else {
             self.data.read_byte(self.range.start + offset)
         }

--- a/common/src/file_slice.rs
+++ b/common/src/file_slice.rs
@@ -260,7 +260,11 @@ impl FileSlice {
 
     /// Reads a single byte without allocating OwnedBytes.
     pub fn read_byte(&self, offset: usize) -> io::Result<u8> {
-        self.data.read_byte(self.range.start + offset)
+        if let Some(slice) = self.as_slice() {
+            Ok(slice[offset])
+        } else {
+            self.data.read_byte(self.range.start + offset)
+        }
     }
 
     /// Returns a direct reference to the underlying bytes if the implementation supports it.

--- a/common/src/file_slice.rs
+++ b/common/src/file_slice.rs
@@ -32,6 +32,25 @@ pub trait FileHandle: 'static + Send + Sync + HasLen + fmt::Debug {
             "Async read is not supported.",
         ))
     }
+
+    /// Reads a single byte without allocating OwnedBytes.
+    ///
+    /// Default implementation goes through `read_bytes()`.
+    /// Implementations backed by block caches can override this for
+    /// zero-allocation access.
+    fn read_byte(&self, offset: usize) -> io::Result<u8> {
+        let data = self.read_bytes(offset..offset + 1)?;
+        Ok(data[0])
+    }
+
+    /// Returns a direct reference to the underlying bytes if available.
+    ///
+    /// In-memory implementations can return `Some` to allow zero-copy access.
+    /// Implementations backed by external storage (e.g. Postgres, disk without mmap)
+    /// should return `None` (the default).
+    fn as_slice(&self) -> Option<&[u8]> {
+        None
+    }
 }
 
 #[derive(Debug)]
@@ -99,6 +118,10 @@ impl FileHandle for &'static [u8] {
 
     async fn read_bytes_async(&self, byte_range: Range<usize>) -> io::Result<OwnedBytes> {
         Ok(self.read_bytes(byte_range)?)
+    }
+
+    fn as_slice(&self) -> Option<&[u8]> {
+        Some(self)
     }
 }
 
@@ -235,6 +258,19 @@ impl FileSlice {
         self.data.read_bytes_async(self.range.clone()).await
     }
 
+    /// Reads a single byte without allocating OwnedBytes.
+    pub fn read_byte(&self, offset: usize) -> io::Result<u8> {
+        self.data.read_byte(self.range.start + offset)
+    }
+
+    /// Returns a direct reference to the underlying bytes if the implementation supports it.
+    ///
+    /// Returns `None` if the underlying storage doesn't support zero-copy access.
+    pub fn as_slice(&self) -> Option<&[u8]> {
+        let all = self.data.as_slice()?;
+        Some(&all[self.range.clone()])
+    }
+
     /// Reads a specific slice of data.
     ///
     /// This is equivalent to running `file_slice.slice(from, to).read_bytes()`.
@@ -320,6 +356,10 @@ impl FileHandle for FileSlice {
     async fn read_bytes_async(&self, byte_range: Range<usize>) -> io::Result<OwnedBytes> {
         self.read_bytes_slice_async(byte_range).await
     }
+
+    fn as_slice(&self) -> Option<&[u8]> {
+        self.as_slice()
+    }
 }
 
 impl HasLen for FileSlice {
@@ -336,6 +376,10 @@ impl FileHandle for OwnedBytes {
 
     async fn read_bytes_async(&self, range: Range<usize>) -> io::Result<OwnedBytes> {
         self.read_bytes(range)
+    }
+
+    fn as_slice(&self) -> Option<&[u8]> {
+        Some(OwnedBytes::as_slice(self))
     }
 }
 

--- a/src/fieldnorm/mod.rs
+++ b/src/fieldnorm/mod.rs
@@ -85,7 +85,7 @@ mod tests {
             assert!(fields_composite.open_read(*FIELD).is_none());
             assert!(fields_composite.open_read(*STR_FIELD).is_none());
             let data = fields_composite.open_read(*TXT_FIELD).unwrap();
-            let fieldnorm_reader = FieldNormReader::open(data)?;
+            let fieldnorm_reader = FieldNormReader::open(data);
             assert_eq!(fieldnorm_reader.fieldnorm(0u32), 0u32);
             assert_eq!(fieldnorm_reader.fieldnorm(1u32), 0u32);
             assert_eq!(fieldnorm_reader.fieldnorm(2u32), 5u32);

--- a/src/fieldnorm/reader.rs
+++ b/src/fieldnorm/reader.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
+use common::HasLen;
+
 use super::{fieldnorm_to_id, id_to_fieldnorm};
-use crate::directory::{CompositeFile, FileSlice, OwnedBytes};
+use crate::directory::{CompositeFile, FileSlice};
 use crate::schema::{Field, Schema};
 use crate::space_usage::PerFieldSpaceUsage;
 use crate::DocId;
@@ -18,7 +20,6 @@ pub struct FieldNormReaders {
 }
 
 impl FieldNormReaders {
-    /// Creates a field norm reader.
     pub fn open(file: FileSlice) -> crate::Result<FieldNormReaders> {
         let data = CompositeFile::open(&file)?;
         Ok(FieldNormReaders {
@@ -29,8 +30,7 @@ impl FieldNormReaders {
     /// Returns the FieldNormReader for a specific field.
     pub fn get_field(&self, field: Field) -> crate::Result<Option<FieldNormReader>> {
         if let Some(file) = self.data.open_read(field) {
-            let fieldnorm_reader = FieldNormReader::open(file)?;
-            Ok(Some(fieldnorm_reader))
+            Ok(Some(FieldNormReader::open(file)))
         } else {
             Ok(None)
         }
@@ -62,11 +62,10 @@ impl From<ReaderImplEnum> for FieldNormReader {
 
 #[derive(Clone)]
 enum ReaderImplEnum {
-    FromData(OwnedBytes),
+    FromFileSlice(FileSlice),
     Const {
         num_docs: u32,
         fieldnorm_id: u8,
-        fieldnorm: u32,
     },
 }
 
@@ -77,59 +76,38 @@ impl FieldNormReader {
     /// from an array-backed fieldnorm reader.
     pub fn constant(num_docs: u32, fieldnorm: u32) -> FieldNormReader {
         let fieldnorm_id = fieldnorm_to_id(fieldnorm);
-        let fieldnorm = id_to_fieldnorm(fieldnorm_id);
         ReaderImplEnum::Const {
             num_docs,
             fieldnorm_id,
-            fieldnorm,
         }
         .into()
     }
 
-    /// Opens a field norm reader given its file.
-    pub fn open(fieldnorm_file: FileSlice) -> crate::Result<Self> {
-        let data = fieldnorm_file.read_bytes()?;
-        Ok(FieldNormReader::new(data))
-    }
-
-    fn new(data: OwnedBytes) -> Self {
-        ReaderImplEnum::FromData(data).into()
+    pub fn open(fieldnorm_file: FileSlice) -> Self {
+        ReaderImplEnum::FromFileSlice(fieldnorm_file).into()
     }
 
     /// Returns the number of documents in this segment.
     pub fn num_docs(&self) -> u32 {
         match &self.0 {
-            ReaderImplEnum::FromData(data) => data.len() as u32,
+            ReaderImplEnum::FromFileSlice(file_slice) => file_slice.len() as u32,
             ReaderImplEnum::Const { num_docs, .. } => *num_docs,
         }
     }
 
     /// Returns the `fieldnorm` associated with a doc id.
-    /// The fieldnorm is a value approximating the number
-    /// of tokens in a given field of the `doc_id`.
-    ///
-    /// It is imprecise, and equal or lower than
-    /// the actual number of tokens.
-    ///
-    /// The fieldnorm is effectively decoded from the
-    /// `fieldnorm_id` by doing a simple table lookup.
     pub fn fieldnorm(&self, doc_id: DocId) -> u32 {
-        match &self.0 {
-            ReaderImplEnum::FromData(data) => {
-                let fieldnorm_id = data.as_slice()[doc_id as usize];
-                id_to_fieldnorm(fieldnorm_id)
-            }
-            ReaderImplEnum::Const { fieldnorm, .. } => *fieldnorm,
-        }
+        id_to_fieldnorm(self.fieldnorm_id(doc_id))
     }
 
     /// Returns the `fieldnorm_id` associated with a document.
     #[inline]
     pub fn fieldnorm_id(&self, doc_id: DocId) -> u8 {
         match &self.0 {
-            ReaderImplEnum::FromData(data) => {
-                let fieldnorm_id = data.as_slice()[doc_id as usize];
-                fieldnorm_id
+            ReaderImplEnum::FromFileSlice(file_slice) => {
+                file_slice
+                    .read_byte(doc_id as usize)
+                    .expect("failed to read fieldnorm byte")
             }
             ReaderImplEnum::Const { fieldnorm_id, .. } => *fieldnorm_id,
         }
@@ -155,8 +133,7 @@ impl FieldNormReader {
             .cloned()
             .map(FieldNormReader::fieldnorm_to_id)
             .collect::<Vec<u8>>();
-        let field_norms_data = OwnedBytes::new(field_norms_id);
-        FieldNormReader::new(field_norms_data)
+        FieldNormReader::open(FileSlice::from(field_norms_id))
     }
 }
 

--- a/src/fieldnorm/reader.rs
+++ b/src/fieldnorm/reader.rs
@@ -63,10 +63,7 @@ impl From<ReaderImplEnum> for FieldNormReader {
 #[derive(Clone)]
 enum ReaderImplEnum {
     FromFileSlice(FileSlice),
-    Const {
-        num_docs: u32,
-        fieldnorm_id: u8,
-    },
+    Const { num_docs: u32, fieldnorm_id: u8 },
 }
 
 impl FieldNormReader {
@@ -104,11 +101,9 @@ impl FieldNormReader {
     #[inline]
     pub fn fieldnorm_id(&self, doc_id: DocId) -> u8 {
         match &self.0 {
-            ReaderImplEnum::FromFileSlice(file_slice) => {
-                file_slice
-                    .read_byte(doc_id as usize)
-                    .expect("failed to read fieldnorm byte")
-            }
+            ReaderImplEnum::FromFileSlice(file_slice) => file_slice
+                .read_byte(doc_id as usize)
+                .expect("failed to read fieldnorm byte"),
             ReaderImplEnum::Const { fieldnorm_id, .. } => *fieldnorm_id,
         }
     }

--- a/src/index/segment_reader.rs
+++ b/src/index/segment_reader.rs
@@ -625,8 +625,7 @@ impl SegmentReader {
             let file = self
                 .open_read(SegmentComponent::FieldNorms)
                 .expect("should be able to open field norms segment component");
-            FieldNormReaders::open(file)
-            .expect("should be able to open field norms readers")
+            FieldNormReaders::open(file).expect("should be able to open field norms readers")
         })
     }
 

--- a/src/index/segment_reader.rs
+++ b/src/index/segment_reader.rs
@@ -622,10 +622,10 @@ impl SegmentReader {
     #[inline]
     fn fieldnorm_readers(&self) -> &FieldNormReaders {
         self.fieldnorm_readers.get_or_init(move || {
-            FieldNormReaders::open(
-                self.open_read(SegmentComponent::FieldNorms)
-                    .expect("should be able to open field norms segment component"),
-            )
+            let file = self
+                .open_read(SegmentComponent::FieldNorms)
+                .expect("should be able to open field norms segment component");
+            FieldNormReaders::open(file)
             .expect("should be able to open field norms readers")
         })
     }


### PR DESCRIPTION
Instead of eagerly reading all fieldnorm data into OwnedBytes at segment open, the reader stores a `FileSlice` and reads bytes on demand via `FileSlice::read_byte()`.

**Changes**

 - Add `FileHandle::read_byte(offset)` and `as_slice()` trait methods for zero-allocation single-byte access
 - `FieldNormReader` stores `FileSlice` instead of eagerly loading all data into `OwnedBytes`
 - `FileSlice::read_byte()` checks `as_slice()` first so mmap/in-memory backends get a direct index with no allocation
 - `FileSlice::read_byte()` returns `Err` on out-of-bounds instead of panicking

**Why**

This is intended for ParadeDB and other block-cache-backed storage systems. With eager loading, opening a segment copies all `fieldnorm` data out of the block cache into a separate OwnedBytes allocation (cheap for mmap). With lazy loading, fieldnorm bytes are read directly from the underlying `FileHandle`, which in ParadeDB's case is the block cache in shared_buffers.

In practice with BMW this is almost always a net positive. It does degrade `ORDER by pdb.score(id) ASC` a little.