### PR TITLE
flatvec: implement the flat vector backend under the unified plugin (3.0)

### DIFF
--- a/columnar/src/column_index/mod.rs
+++ b/columnar/src/column_index/mod.rs
@@ -12,7 +12,7 @@ use std::ops::Range;
 
 pub use merge::merge_column_index;
 pub(crate) use multivalued_index::SerializableMultivalueIndex;
-pub use optional_index::{OptionalIndex, Set};
+pub use optional_index::{OptionalIndex, Set, open_optional_index, serialize_optional_index};
 pub use serialize::{
     SerializableColumnIndex, SerializableOptionalIndex, open_column_index, serialize_column_index,
 };

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -13,6 +13,8 @@ use crate::collector::sort_key_top_collector::TopBySortKeyCollector;
 use crate::collector::top_collector::ComparableDoc;
 use crate::collector::{SegmentSortKeyComputer, SortKeyComputer};
 use crate::fastfield::FastValue;
+use crate::schema::Field;
+use crate::vector::{TopDocsByVectorSimilarity, VectorElement};
 use crate::{DocAddress, DocId, Order, Score, SegmentOrdinal, SegmentReader};
 
 /// The `TopDocs` collector keeps track of the top `K` documents
@@ -327,6 +329,39 @@ impl TopDocs {
         TSortKey: 'static + Clone + Send + Sync + std::fmt::Debug,
     {
         TopBySortKeyCollector::new(sort_key_computer, self.doc_range())
+    }
+
+    /// Ranks documents by similarity to a query vector against a
+    /// [`FieldType::Vector`](crate::schema::FieldType::Vector) field.
+    ///
+    /// The metric is read from the field's
+    /// [`VectorOptions`](crate::schema::VectorOptions) at query time —
+    /// callers don't pick a metric here. All metrics are presented in
+    /// "higher is better" form (L2 is internally negated), so this is
+    /// always a descending sort: the closest docs come first.
+    ///
+    /// Only documents that have a vector for `field` are returned —
+    /// filter-matching docs without a vector are dropped. This differs
+    /// from `order_by_fast_field`'s `None`-trailing convention; the
+    /// constraint comes from IVF, which can't see vectorless docs.
+    ///
+    /// Generic over `T: VectorElement` — `T` is typically `f32` and is
+    /// inferred from the `query` argument; it must match the schema's
+    /// declared dtype.
+    ///
+    /// The driving query (passed to `searcher.search`) decides which docs
+    /// are candidates. For brute-force scan over every doc, pair this with
+    /// [`AllQuery`](crate::query::AllQuery); pair with a filter query to
+    /// restrict candidates.
+    pub fn order_by_similarity<T>(
+        self,
+        field: Field,
+        query: Vec<T>,
+    ) -> TopDocsByVectorSimilarity<T>
+    where
+        T: VectorElement,
+    {
+        TopDocsByVectorSimilarity::new(field, query, self.limit).and_offset(self.offset)
     }
 
     /// Helper function to tweak the similarity score of documents using a function.
@@ -675,6 +710,26 @@ where
         self.append_doc(doc, sort_key);
     }
 
+    /// Like [`push`](Self::push), but doesn't require pushes to arrive
+    /// in ascending `DocId`/`DocAddress` order.
+    ///
+    /// The default `push` short-circuits below-threshold candidates with
+    /// a strict `> threshold` test. That's only safe under ascending-D
+    /// pushes — equal-sort-key future pushes are guaranteed to have a
+    /// larger D and thus lose the tie-break, so they can be skipped.
+    /// Out-of-order callers (eg a vector IVF format which visits cluster
+    /// by cluster) can't make that guarantee, so this path relaxes the
+    /// skip to strictly less than the threshold.
+    #[inline]
+    pub fn push_unordered(&mut self, sort_key: TSortKey, doc: D) {
+        if let Some((last_median, _thresh_ord)) = &self.threshold {
+            if self.comparator.compare(&sort_key, last_median) == std::cmp::Ordering::Less {
+                return;
+            }
+        }
+        self.append_doc(doc, sort_key);
+    }
+
     // Append a document to the top n.
     //
     // At this point, we need to have established that the doc is above the threshold.
@@ -870,6 +925,62 @@ mod tests {
                 ComparableDoc {
                     sort_key: 1u32,
                     doc: 2u32,
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_topn_computer_push_unordered() {
+        // Same inputs as test_topn_computer, but pushed in a non-ascending
+        // DocId order — push_unordered should still produce the right top-K
+        // and (where ties exist) the smallest-DocId tie-break.
+        let mut computer: TopNComputer<u32, u32, NaturalComparator> =
+            TopNComputer::new_with_comparator(2, NaturalComparator);
+
+        computer.push_unordered(3u32, 3u32);
+        computer.push_unordered(1u32, 5u32);
+        computer.push_unordered(2u32, 2u32);
+        computer.push_unordered(2u32, 4u32);
+        computer.push_unordered(1u32, 1u32);
+        assert_eq!(
+            computer.into_sorted_vec(),
+            &[
+                ComparableDoc {
+                    sort_key: 3u32,
+                    doc: 3u32,
+                },
+                ComparableDoc {
+                    sort_key: 2u32,
+                    doc: 2u32,
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_topn_computer_push_unordered_tiebreak_on_equal_sort_key() {
+        // Tied sort keys must still resolve to the smallest DocId, even when
+        // doc ids arrive out of order (and even when the smaller-DocId
+        // candidate arrives *after* the larger-DocId one).
+        let mut computer: TopNComputer<u32, u32, NaturalComparator> =
+            TopNComputer::new_with_comparator(2, NaturalComparator);
+
+        computer.push_unordered(1u32, 100u32);
+        computer.push_unordered(1u32, 50u32);
+        computer.push_unordered(1u32, 200u32);
+        computer.push_unordered(1u32, 25u32);
+        computer.push_unordered(1u32, 175u32);
+        assert_eq!(
+            computer.into_sorted_vec(),
+            &[
+                ComparableDoc {
+                    sort_key: 1u32,
+                    doc: 25u32,
+                },
+                ComparableDoc {
+                    sort_key: 1u32,
+                    doc: 50u32,
                 }
             ]
         );

--- a/src/index/index.rs
+++ b/src/index/index.rs
@@ -30,6 +30,7 @@ use crate::schema::document::Document;
 use crate::schema::{Field, FieldType, Schema, Type};
 use crate::store::StorePlugin;
 use crate::tokenizer::{TextAnalyzer, TokenizerManager};
+use crate::vector::VectorPlugin;
 use crate::SegmentReader;
 
 fn load_metas(
@@ -69,6 +70,7 @@ pub(crate) fn builtin_plugins() -> Vec<Arc<dyn SegmentPlugin>> {
         Arc::new(PostingsPlugin),
         Arc::new(FastFieldsPlugin),
         Arc::new(StorePlugin),
+        Arc::new(VectorPlugin),
     ]
 }
 

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -233,6 +233,7 @@ impl SegmentWriter {
                     field_entry.name()
                 ))
             };
+
             if !field_entry.is_indexed() {
                 continue;
             }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -63,11 +63,14 @@ pub trait SegmentPlugin: Send + Sync + 'static {
     ) -> crate::Result<BTreeMap<String, ComponentSpaceUsage>> {
         let mut usage = BTreeMap::new();
         for &ext in self.extensions() {
-            let file = segment_reader.open_read(SegmentComponent::Custom(ext.to_string()))?;
-            usage.insert(
-                ext.to_string(),
-                ComponentSpaceUsage::Basic(file.len().into()),
-            );
+            // A plugin's per-segment file may be absent (e.g. a vector segment with no
+            // vector-typed fields), so skip extensions with no file rather than erroring.
+            if let Ok(file) = segment_reader.open_read(SegmentComponent::Custom(ext.to_string())) {
+                usage.insert(
+                    ext.to_string(),
+                    ComponentSpaceUsage::Basic(file.len().into()),
+                );
+            }
         }
         Ok(usage)
     }

--- a/src/vector/backend.rs
+++ b/src/vector/backend.rs
@@ -1,0 +1,123 @@
+//! Per-segment dispatch over vector storage formats.
+//!
+//! Picked once per segment by
+//! [`TopDocsByVectorSimilarity`](super::collector::TopDocsByVectorSimilarity). The backend owns
+//! its top-N loop: [`FlatBackend`] iterates the filter `Scorer` doc-by-doc.
+//!
+//! Adding a new format (IVF, HNSW, etc.) is a new enum variant — the
+//! collector layer doesn't change.
+
+use std::sync::Arc;
+
+use super::flat::FlatVectorColumn;
+use super::reader::{VectorColumn, VectorColumnReader, VectorReader};
+use super::VectorElement;
+use crate::collector::TopNComputer;
+use crate::query::Weight;
+use crate::schema::{Field, FieldType, Metric, Schema};
+use crate::{DocAddress, DocId, Score, SegmentOrdinal, SegmentReader, TantivyError};
+
+/// Per-segment vector backend. Pick via [`VectorBackend::for_segment`].
+pub enum VectorBackend<T: VectorElement> {
+    Flat(FlatBackend<T>),
+}
+
+pub struct FlatBackend<T: VectorElement> {
+    column: FlatVectorColumn,
+    metric: Metric,
+    query: Arc<Vec<T>>,
+    segment_ord: SegmentOrdinal,
+}
+
+impl<T: VectorElement> VectorBackend<T> {
+    /// Open the segment's vector column using the storage format recorded in
+    /// vector metadata.
+    /// Returns an error if the segment has no vector data at all.
+    pub fn for_segment(
+        segment_reader: &SegmentReader,
+        segment_ord: SegmentOrdinal,
+        field: Field,
+        query: Arc<Vec<T>>,
+    ) -> crate::Result<Self> {
+        let schema = segment_reader.schema();
+        let metric = lookup_metric(schema, field)?;
+
+        let vec_reader = VectorReader::open(segment_reader)?;
+
+        match vec_reader.open_column(field)? {
+            VectorColumn::Flat(column) => Ok(Self::Flat(FlatBackend {
+                column,
+                metric,
+                query,
+                segment_ord,
+            })),
+        }
+    }
+
+    /// Top-N within this segment.
+    /// Hits come back already tagged with `DocAddress` (the backend
+    /// holds its own `SegmentOrdinal`), so the collector doesn't need
+    /// a second pass to attach the segment.
+    pub fn top_n(
+        &self,
+        weight: &dyn Weight,
+        segment_reader: &SegmentReader,
+        top_n: usize,
+    ) -> crate::Result<Vec<(Score, DocAddress)>> {
+        match self {
+            Self::Flat(b) => b.top_n(weight, segment_reader, top_n),
+        }
+    }
+}
+
+impl<T: VectorElement> FlatBackend<T> {
+    fn top_n(
+        &self,
+        weight: &dyn Weight,
+        segment_reader: &SegmentReader,
+        top_n: usize,
+    ) -> crate::Result<Vec<(Score, DocAddress)>> {
+        // `for_each_no_score` walks the filter DocSet in ascending doc
+        // order, which lets us use the fast `TopNComputer::push` path
+        // (strict-greater threshold short-circuit, valid only under
+        // ascending-D pushes).
+        //
+        // The heap keys on segment-local `DocId` (cheaper compares than
+        // `DocAddress`); we tag with `self.segment_ord` at drain time
+        // so the collector returns ready-to-use `DocAddress`es without
+        // a second pass.
+        let mut topn = TopNComputer::<Score, DocId, _>::new(top_n);
+        let alive = segment_reader.alive_bitset();
+        weight.for_each_no_score(segment_reader, &mut |docs| {
+            for &doc in docs {
+                if let Some(bs) = alive {
+                    if !bs.is_alive(doc) {
+                        continue;
+                    }
+                }
+                if let Some(bytes) = self.column.vector_bytes_at(doc) {
+                    let score = self.metric.similarity_bytes(&self.query[..], bytes);
+                    topn.push(score, doc);
+                }
+            }
+        })?;
+        let segment_ord = self.segment_ord;
+        Ok(topn
+            .into_sorted_vec()
+            .into_iter()
+            .map(|cd| (cd.sort_key, DocAddress::new(segment_ord, cd.doc)))
+            .collect())
+    }
+}
+
+fn lookup_metric(schema: &Schema, field: Field) -> crate::Result<Metric> {
+    let entry = schema.get_field_entry(field);
+    match entry.field_type() {
+        FieldType::Vector(opts) => Ok(opts.metric()),
+        other => Err(TantivyError::SchemaError(format!(
+            "field {:?} is not a vector field (got {:?})",
+            entry.name(),
+            other.value_type(),
+        ))),
+    }
+}

--- a/src/vector/collector.rs
+++ b/src/vector/collector.rs
@@ -1,0 +1,147 @@
+//! Top-N vector-similarity collector.
+//!
+//! Unlike the other `TopDocs::order_by_*` paths, vector similarity is
+//! not a [`SortKeyComputer`](crate::collector::sort_key::SortKeyComputer).
+//! It is its own [`Collector`] with an overridden
+//! [`Collector::collect_segment`] that hands the filter `Weight` down to
+//! the per-segment [`VectorBackend`](super::backend::VectorBackend),
+//! which owns the loop.
+
+use std::cmp::Ordering;
+use std::sync::Arc;
+
+use super::backend::VectorBackend;
+use super::VectorElement;
+use crate::collector::{Collector, SegmentCollector};
+use crate::index::SegmentReader;
+use crate::query::Weight;
+use crate::schema::{Field, FieldType, Schema};
+use crate::{DocAddress, DocId, Score, SegmentOrdinal, TantivyError};
+
+/// Top-N by vector similarity. Returns documents in descending
+/// similarity order. Only docs that actually have a vector are
+/// returned — docs that match the filter but lack a vector for `field`
+/// are dropped.
+///
+/// Generic over `T: VectorElement` — `T` must match the schema's
+/// declared dtype, checked at [`Collector::check_schema`] time.
+pub struct TopDocsByVectorSimilarity<T: VectorElement> {
+    field: Field,
+    query: Arc<Vec<T>>,
+    limit: usize,
+    offset: usize,
+}
+
+impl<T: VectorElement> TopDocsByVectorSimilarity<T> {
+    pub fn new(field: Field, query: Vec<T>, limit: usize) -> Self {
+        Self {
+            field,
+            query: Arc::new(query),
+            limit,
+            offset: 0,
+        }
+    }
+
+    /// Drop the first `offset` results in the global ranking — used to
+    /// paginate. Each segment still produces its top `limit + offset`
+    /// to ensure the global window has enough candidates.
+    pub fn and_offset(mut self, offset: usize) -> Self {
+        self.offset = offset;
+        self
+    }
+
+    fn segment_top_n(&self) -> usize {
+        self.limit.saturating_add(self.offset)
+    }
+}
+
+impl<T: VectorElement> Collector for TopDocsByVectorSimilarity<T> {
+    type Fruit = Vec<(Score, DocAddress)>;
+    type Child = NoOpSegmentCollector;
+
+    fn check_schema(&self, schema: &Schema) -> crate::Result<()> {
+        let entry = schema.get_field_entry(self.field);
+        let opts = match entry.field_type() {
+            FieldType::Vector(o) => o,
+            _ => {
+                return Err(TantivyError::SchemaError(format!(
+                    "field {:?} is not a vector field",
+                    entry.name(),
+                )));
+            }
+        };
+        if opts.dim() != self.query.len() {
+            return Err(TantivyError::SchemaError(format!(
+                "query vector length {} does not match field {:?} dim {}",
+                self.query.len(),
+                entry.name(),
+                opts.dim(),
+            )));
+        }
+        if opts.dtype() != T::DTYPE {
+            return Err(TantivyError::SchemaError(format!(
+                "query dtype {:?} does not match field {:?} dtype {:?}",
+                T::DTYPE,
+                entry.name(),
+                opts.dtype(),
+            )));
+        }
+        Ok(())
+    }
+
+    fn for_segment(
+        &self,
+        _segment_local_id: SegmentOrdinal,
+        _reader: &SegmentReader,
+    ) -> crate::Result<Self::Child> {
+        // Never called at runtime — we override `collect_segment`. The
+        // child type exists only to satisfy the trait bound.
+        Ok(NoOpSegmentCollector)
+    }
+
+    fn requires_scoring(&self) -> bool {
+        // Similarity is computed from the stored vectors, not from the
+        // filter's BM25 score — let tantivy take the no-score fast path.
+        false
+    }
+
+    fn collect_segment(
+        &self,
+        weight: &dyn Weight,
+        segment_ord: SegmentOrdinal,
+        reader: &SegmentReader,
+    ) -> crate::Result<Vec<(Score, DocAddress)>> {
+        let backend =
+            VectorBackend::for_segment(reader, segment_ord, self.field, Arc::clone(&self.query))?;
+        backend.top_n(weight, reader, self.segment_top_n())
+    }
+
+    fn merge_fruits(
+        &self,
+        segment_fruits: Vec<Vec<(Score, DocAddress)>>,
+    ) -> crate::Result<Self::Fruit> {
+        // Per-segment fruits are each already top-(limit+offset);
+        // flatten, sort descending, drop offset, truncate to limit.
+        let mut all: Vec<(Score, DocAddress)> = segment_fruits.into_iter().flatten().collect();
+        all.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(Ordering::Equal));
+        if self.offset >= all.len() {
+            return Ok(Vec::new());
+        }
+        all.drain(..self.offset);
+        all.truncate(self.limit);
+        Ok(all)
+    }
+}
+
+/// Trait-bound shim: the collector overrides [`Collector::collect_segment`]
+/// so the per-doc path never fires, but the `Child: SegmentCollector`
+/// bound on `Collector` still has to be satisfied.
+pub struct NoOpSegmentCollector;
+
+impl SegmentCollector for NoOpSegmentCollector {
+    type Fruit = Vec<(Score, DocAddress)>;
+    fn collect(&mut self, _doc: DocId, _score: Score) {}
+    fn harvest(self) -> Self::Fruit {
+        Vec::new()
+    }
+}

--- a/src/vector/distance.rs
+++ b/src/vector/distance.rs
@@ -1,0 +1,304 @@
+//! Distance kernels for the flat vector index.
+//!
+//! Each kernel uses a chunked-scalar accumulator pattern: an array of
+//! `LANES` independent f32 accumulators with no loop-carried dependency.
+//! LLVM's autovectorizer turns this into AVX2 / AVX-512 / NEON FMA loops
+//! on the platforms that support them, without any explicit `std::arch`
+//! intrinsics.
+//!
+//! `LANES = 16` matches the f32 width of an AVX-512 register
+//! (`512 bits / sizeof::<f32>() == 16`), and is a multiple of the AVX2
+//! (8) and NEON (4) widths.
+//!
+//! Kernels are generic over [`VectorElement`]. For `f32` the arithmetic
+//! methods compile to plain `fsub` / `fmul` / `fadd`; quantized dtypes
+//! plug in their own decode + arithmetic via the trait.
+
+use crate::schema::Metric;
+use crate::vector::VectorElement;
+
+/// 16 = 512 (avx512 register width) / 32 (sizeof::<f32>() in bits).
+const LANES: usize = 16;
+
+/// Squared Euclidean distance.
+#[inline]
+pub fn l2_squared<T: VectorElement>(a: &[T], b: &[T]) -> f32 {
+    debug_assert_eq!(a.len(), b.len());
+    let a_chunks = a.chunks_exact(LANES);
+    let b_chunks = b.chunks_exact(LANES);
+    let a_tail = a_chunks.remainder();
+    let b_tail = b_chunks.remainder();
+
+    let mut sums = [0f32; LANES];
+    for (ac, bc) in a_chunks.zip(b_chunks) {
+        for i in 0..LANES {
+            sums[i] += T::squared_diff(ac[i], bc[i]);
+        }
+    }
+    let mut acc: f32 = sums.iter().sum();
+    for (&x, &y) in a_tail.iter().zip(b_tail.iter()) {
+        acc += T::squared_diff(x, y);
+    }
+    acc
+}
+
+/// Dot product.
+#[inline]
+pub fn dot<T: VectorElement>(a: &[T], b: &[T]) -> f32 {
+    debug_assert_eq!(a.len(), b.len());
+    let a_chunks = a.chunks_exact(LANES);
+    let b_chunks = b.chunks_exact(LANES);
+    let a_tail = a_chunks.remainder();
+    let b_tail = b_chunks.remainder();
+
+    let mut sums = [0f32; LANES];
+    for (ac, bc) in a_chunks.zip(b_chunks) {
+        for i in 0..LANES {
+            sums[i] += T::product(ac[i], bc[i]);
+        }
+    }
+    let mut acc: f32 = sums.iter().sum();
+    for (&x, &y) in a_tail.iter().zip(b_tail.iter()) {
+        acc += T::product(x, y);
+    }
+    acc
+}
+
+/// Sum of squares (squared L2 norm).
+#[inline]
+pub fn norm_squared<T: VectorElement>(a: &[T]) -> f32 {
+    let chunks = a.chunks_exact(LANES);
+    let tail = chunks.remainder();
+
+    let mut sums = [0f32; LANES];
+    for c in chunks {
+        for i in 0..LANES {
+            sums[i] += T::product(c[i], c[i]);
+        }
+    }
+    let mut acc: f32 = sums.iter().sum();
+    for &x in tail {
+        acc += T::product(x, x);
+    }
+    acc
+}
+
+/// Cosine similarity: `dot(a, b) / (||a|| * ||b||)`. Returns 0.0 if either
+/// vector has zero norm — avoids NaN propagating into top-K heaps.
+#[inline]
+pub fn cosine<T: VectorElement>(a: &[T], b: &[T]) -> f32 {
+    let na = norm_squared(a).sqrt();
+    let nb = norm_squared(b).sqrt();
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot(a, b) / (na * nb)
+}
+
+// =====================================================================
+// Byte-input variants: avoid materializing the doc-side vector into an
+// intermediate scratch buffer. The doc bytes are decoded inline inside
+// the chunked accumulator, so the segment scan touches each byte
+// exactly once regardless of directory backend (mmap, RAM, or custom).
+// =====================================================================
+
+/// `l2_squared` where the doc side is little-endian bytes encoding `T`.
+///
+/// Uses `chunks_exact` so LLVM sees fixed-length inner slices and can
+/// elide bounds checks + autovectorize the chunked accumulator into
+/// 4-wide NEON / 8-wide AVX2 / 16-wide AVX-512 SIMD.
+#[inline]
+pub fn l2_squared_bytes<T: VectorElement>(query: &[T], doc_bytes: &[u8]) -> f32 {
+    debug_assert_eq!(doc_bytes.len(), query.len() * T::SIZE_BYTES);
+    let q_chunks = query.chunks_exact(LANES);
+    let b_chunks = doc_bytes.chunks_exact(LANES * T::SIZE_BYTES);
+    let q_tail = q_chunks.remainder();
+    let b_tail = b_chunks.remainder();
+
+    let mut sums = [0f32; LANES];
+    for (qc, bc) in q_chunks.zip(b_chunks) {
+        for i in 0..LANES {
+            let v = T::decode_le(&bc[i * T::SIZE_BYTES..(i + 1) * T::SIZE_BYTES]);
+            sums[i] += T::squared_diff(qc[i], v);
+        }
+    }
+    let mut acc: f32 = sums.iter().sum();
+    for (i, &q) in q_tail.iter().enumerate() {
+        let v = T::decode_le(&b_tail[i * T::SIZE_BYTES..(i + 1) * T::SIZE_BYTES]);
+        acc += T::squared_diff(q, v);
+    }
+    acc
+}
+
+/// `dot` where the doc side is little-endian bytes encoding `T`.
+#[inline]
+pub fn dot_bytes<T: VectorElement>(query: &[T], doc_bytes: &[u8]) -> f32 {
+    debug_assert_eq!(doc_bytes.len(), query.len() * T::SIZE_BYTES);
+    let q_chunks = query.chunks_exact(LANES);
+    let b_chunks = doc_bytes.chunks_exact(LANES * T::SIZE_BYTES);
+    let q_tail = q_chunks.remainder();
+    let b_tail = b_chunks.remainder();
+
+    let mut sums = [0f32; LANES];
+    for (qc, bc) in q_chunks.zip(b_chunks) {
+        for i in 0..LANES {
+            let v = T::decode_le(&bc[i * T::SIZE_BYTES..(i + 1) * T::SIZE_BYTES]);
+            sums[i] += T::product(qc[i], v);
+        }
+    }
+    let mut acc: f32 = sums.iter().sum();
+    for (i, &q) in q_tail.iter().enumerate() {
+        let v = T::decode_le(&b_tail[i * T::SIZE_BYTES..(i + 1) * T::SIZE_BYTES]);
+        acc += T::product(q, v);
+    }
+    acc
+}
+
+/// `norm_squared` over little-endian bytes encoding `T`.
+#[inline]
+pub fn norm_squared_bytes<T: VectorElement>(doc_bytes: &[u8]) -> f32 {
+    debug_assert_eq!(doc_bytes.len() % T::SIZE_BYTES, 0);
+    let b_chunks = doc_bytes.chunks_exact(LANES * T::SIZE_BYTES);
+    let b_tail = b_chunks.remainder();
+
+    let mut sums = [0f32; LANES];
+    for bc in b_chunks {
+        for i in 0..LANES {
+            let v = T::decode_le(&bc[i * T::SIZE_BYTES..(i + 1) * T::SIZE_BYTES]);
+            sums[i] += T::product(v, v);
+        }
+    }
+    let mut acc: f32 = sums.iter().sum();
+    let tail_dim = b_tail.len() / T::SIZE_BYTES;
+    for i in 0..tail_dim {
+        let v = T::decode_le(&b_tail[i * T::SIZE_BYTES..(i + 1) * T::SIZE_BYTES]);
+        acc += T::product(v, v);
+    }
+    acc
+}
+
+/// `cosine` where the doc side is little-endian bytes encoding `T`.
+#[inline]
+pub fn cosine_bytes<T: VectorElement>(query: &[T], doc_bytes: &[u8]) -> f32 {
+    let nq = norm_squared(query).sqrt();
+    let nd = norm_squared_bytes::<T>(doc_bytes).sqrt();
+    if nq == 0.0 || nd == 0.0 {
+        return 0.0;
+    }
+    dot_bytes(query, doc_bytes) / (nq * nd)
+}
+
+impl Metric {
+    /// Compute a "higher is better" similarity score between two vectors.
+    ///
+    /// L2 distance is negated (squared, then sign-flipped) so all metrics
+    /// share the same ranking convention. Magnitude differences across
+    /// metrics are the caller's problem.
+    #[inline]
+    pub fn similarity<T: VectorElement>(self, query: &[T], doc: &[T]) -> f32 {
+        match self {
+            Metric::L2 => -l2_squared(query, doc),
+            Metric::Cosine => cosine(query, doc),
+            Metric::Dot => dot(query, doc),
+        }
+    }
+
+    /// Like [`similarity`](Self::similarity), but the doc side is
+    /// little-endian bytes — typically a borrowed slice straight out
+    /// of the segment's file.
+    #[inline]
+    pub fn similarity_bytes<T: VectorElement>(self, query: &[T], doc_bytes: &[u8]) -> f32 {
+        match self {
+            Metric::L2 => -l2_squared_bytes(query, doc_bytes),
+            Metric::Cosine => cosine_bytes(query, doc_bytes),
+            Metric::Dot => dot_bytes(query, doc_bytes),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::Metric;
+
+    #[test]
+    fn test_l2_squared() {
+        let a: [f32; 4] = [1.0, 2.0, 3.0, 4.0];
+        let b: [f32; 4] = [4.0, 3.0, 2.0, 1.0];
+        // (1-4)^2 + (2-3)^2 + (3-2)^2 + (4-1)^2 = 9+1+1+9 = 20
+        assert!((l2_squared(&a, &b) - 20.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_dot() {
+        let a: [f32; 3] = [1.0, 2.0, 3.0];
+        let b: [f32; 3] = [4.0, 5.0, 6.0];
+        // 1*4 + 2*5 + 3*6 = 4+10+18 = 32
+        assert!((dot(&a, &b) - 32.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_cosine_identical() {
+        let a: [f32; 2] = [3.0, 4.0];
+        assert!((cosine(&a, &a) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_cosine_orthogonal() {
+        let a: [f32; 2] = [1.0, 0.0];
+        let b: [f32; 2] = [0.0, 1.0];
+        assert!(cosine(&a, &b).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_cosine_opposite() {
+        let a: [f32; 2] = [1.0, 0.0];
+        let b: [f32; 2] = [-1.0, 0.0];
+        assert!((cosine(&a, &b) + 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_cosine_zero_norm() {
+        let a: [f32; 2] = [0.0, 0.0];
+        let b: [f32; 2] = [1.0, 0.0];
+        assert_eq!(cosine(&a, &b), 0.0);
+    }
+
+    #[test]
+    fn test_higher_is_better_ranking() {
+        let query: [f32; 3] = [1.0, 0.0, 0.0];
+        let near: [f32; 3] = [1.0, 0.1, 0.0];
+        let far: [f32; 3] = [-1.0, 0.0, 0.0];
+        for m in [Metric::L2, Metric::Cosine, Metric::Dot] {
+            let s_near = m.similarity(&query, &near);
+            let s_far = m.similarity(&query, &far);
+            assert!(s_near > s_far, "metric {m:?}: {s_near} vs {s_far}");
+        }
+    }
+
+    #[test]
+    fn test_byte_kernels_match_f32_kernels() {
+        // Random-ish data that exercises both the chunked path and the tail.
+        let dim = LANES + 5;
+        let a: Vec<f32> = (0..dim).map(|i| (i as f32) * 0.137 - 1.3).collect();
+        let b: Vec<f32> = (0..dim).map(|i| (i as f32).sin()).collect();
+        let b_bytes: Vec<u8> = b.iter().flat_map(|v| v.to_le_bytes()).collect();
+
+        let eps = 1e-5;
+        assert!((l2_squared(&a, &b) - l2_squared_bytes::<f32>(&a, &b_bytes)).abs() < eps);
+        assert!((dot(&a, &b) - dot_bytes::<f32>(&a, &b_bytes)).abs() < eps);
+        assert!((cosine(&a, &b) - cosine_bytes::<f32>(&a, &b_bytes)).abs() < eps);
+        assert!((norm_squared(&b) - norm_squared_bytes::<f32>(&b_bytes)).abs() < eps);
+    }
+
+    #[test]
+    fn test_long_vector_chunking() {
+        // Exercise both the chunked path and the tail.
+        let dim = LANES * 2 + 3;
+        let a: Vec<f32> = (0..dim).map(|i| i as f32 * 0.1).collect();
+        let b: Vec<f32> = (0..dim).map(|i| (i + 1) as f32 * 0.1).collect();
+        // L2² = sum (-0.1)^2 = dim * 0.01
+        let expected = dim as f32 * 0.01;
+        assert!((l2_squared(&a, &b) - expected).abs() < 1e-4);
+    }
+}

--- a/src/vector/flat/mod.rs
+++ b/src/vector/flat/mod.rs
@@ -1,0 +1,13 @@
+mod plugin;
+mod presence;
+mod reader;
+mod writer;
+
+pub(crate) const FLATVEC_EXT: &str = "flatvec";
+
+pub(crate) use plugin::merge_flat;
+pub use reader::{FlatVecReader, FlatVectorColumn};
+pub use writer::FlatVecWriter;
+
+#[cfg(test)]
+mod tests;

--- a/src/vector/flat/plugin.rs
+++ b/src/vector/flat/plugin.rs
@@ -1,0 +1,103 @@
+//! Flat-format merge routine.
+//!
+//! The flat format is one of two storage modes the unified
+//! [`VectorPlugin`](crate::vector::VectorPlugin) can produce per merge.
+//! This module exposes the merge body — copying raw vector bytes from
+//! source segments into a single `.flatvec` composite file — so the
+//! parent plugin can call it after the threshold check.
+
+use std::io::Write;
+
+use common::TerminatingWrite;
+
+use super::presence::Presence;
+use crate::directory::{CompositeWrite, Directory};
+use crate::index::SegmentComponent;
+use crate::plugin::PluginMergeContext;
+use crate::schema::FieldType;
+use crate::vector::meta::{VectorStorageFormat, VECMETA_EXT};
+use crate::vector::reader::{VectorColumnReader, VectorReader};
+use crate::DocId;
+
+/// Merge source vectors into the target segment's `.flatvec` file.
+///
+/// Caller (`VectorPlugin::merge`) has already verified that the target
+/// segment's doc count is below the clustering threshold. This routine
+/// is unconditional — it always writes flatvec when called.
+pub(crate) fn merge_flat(ctx: &PluginMergeContext) -> crate::Result<()> {
+    let has_vector_field = ctx
+        .schema
+        .fields()
+        .any(|(_, entry)| matches!(entry.field_type(), FieldType::Vector(_)));
+    if !has_vector_field {
+        return Ok(());
+    }
+    if ctx.cancel.wants_cancel() {
+        return Err(crate::TantivyError::Cancelled);
+    }
+    let meta_path = ctx
+        .target_segment
+        .relative_path(SegmentComponent::Custom(VECMETA_EXT.to_string()));
+    let mut meta_write = ctx
+        .target_segment
+        .index()
+        .directory()
+        .open_write(&meta_path)?;
+    VectorStorageFormat::Flat.serialize(&mut meta_write)?;
+    meta_write.terminate()?;
+
+    let path = ctx
+        .target_segment
+        .relative_path(SegmentComponent::Custom(super::FLATVEC_EXT.to_string()));
+    let write = ctx.target_segment.index().directory().open_write(&path)?;
+    let source_readers: Vec<VectorReader> = ctx
+        .readers
+        .iter()
+        .map(VectorReader::open)
+        .collect::<crate::Result<Vec<_>>>()?;
+
+    let mut composite = CompositeWrite::wrap(write);
+
+    // num_docs in the target segment = number of alive docs aggregated
+    // by the doc_id_mapping. Each call to iter_old_doc_addrs yields
+    // exactly num_new_doc_ids items.
+    let num_target_docs: u32 = ctx.readers.iter().map(|r| r.num_docs()).sum::<u32>();
+
+    for (field, entry) in ctx.schema.fields() {
+        let _opts = match entry.field_type() {
+            FieldType::Vector(opts) => opts,
+            _ => continue,
+        };
+
+        // Per-segment column views for this field (lazy open).
+        let columns: Vec<_> = source_readers
+            .iter()
+            .map(|reader| reader.open_column(field))
+            .collect::<crate::Result<Vec<_>>>()?;
+
+        let mut target_present: Vec<DocId> = Vec::new();
+        let mut new_doc_id: DocId = 0;
+        {
+            let rows_w = composite.for_field_with_idx(field, 1);
+            for old_doc_addr in ctx.doc_id_mapping.iter_old_doc_addrs() {
+                let column = &columns[old_doc_addr.segment_ord as usize];
+                if let Some(bytes) = column.vector_bytes_at(old_doc_addr.doc_id) {
+                    target_present.push(new_doc_id);
+                    rows_w.write_all(bytes)?;
+                }
+                new_doc_id += 1;
+            }
+            rows_w.flush()?;
+        }
+
+        // Sanity: the mapping iterator should yield exactly num_target_docs items.
+        debug_assert_eq!(new_doc_id, num_target_docs);
+
+        // Slice (field, 0): presence section (Full or Optional).
+        let bitmap_w = composite.for_field_with_idx(field, 0);
+        Presence::serialize(&target_present, num_target_docs, bitmap_w)?;
+        bitmap_w.flush()?;
+    }
+    composite.close()?;
+    Ok(())
+}

--- a/src/vector/flat/presence.rs
+++ b/src/vector/flat/presence.rs
@@ -1,0 +1,208 @@
+//! Per-segment presence tracker for vector fields.
+//!
+//! Marks which `doc_id`s have a value for a given vector field. Used to
+//! address the dense row array via rank (`rank(doc_id) -> row_id`) and
+//! to distinguish "missing vector" from "zero vector" at query time.
+//!
+//! Mirrors the `Full | Optional` cardinality split in
+//! `tantivy-columnar`. For dense columns (every doc present — the
+//! typical case for embeddings) the `Full` variant skips the bitmap
+//! entirely: `row_id == doc_id` is the identity map, no rank lookup
+//! needed. For sparse columns we delegate to columnar's
+//! [`OptionalIndex`], a roaring-style bitmap with rank/select support
+//! that's also used by fast-field columns elsewhere in tantivy.
+//!
+//! ## On-disk layout
+//!
+//! ```text
+//! [u8 variant_tag] [body]
+//!   tag = 0  (Full):     no body — `num_docs` comes from the caller
+//!                        (typically `segment_reader.max_doc()`)
+//!   tag = 1  (Optional): body = serialized columnar OptionalIndex
+//! ```
+
+use std::io::{self, Write};
+
+use columnar::column_index::{open_optional_index, serialize_optional_index, OptionalIndex, Set};
+use common::HasLen;
+
+use crate::directory::FileSlice;
+use crate::DocId;
+
+const VARIANT_FULL: u8 = 0;
+const VARIANT_OPTIONAL: u8 = 1;
+
+/// Per-field presence tracker. Dispatches on cardinality at open time so
+/// the hot path can skip the bitmap entirely when every doc has a value.
+pub enum Presence {
+    /// Every doc has a value. `row_id == doc_id`; no bitmap stored.
+    Full { num_docs: u32 },
+    /// Some docs may be absent. Rank/contains go through columnar's
+    /// `OptionalIndex` (roaring-style block bitmap).
+    Optional(OptionalIndex),
+}
+
+impl Presence {
+    /// Serialize the appropriate variant given a sorted list of present
+    /// `doc_id`s. Chooses `Full` if every doc is present, `Optional`
+    /// otherwise.
+    ///
+    /// The Full variant writes only the variant tag — `num_docs` is
+    /// supplied at open time (typically from `segment_reader.max_doc()`).
+    pub fn serialize<W: Write>(
+        present_doc_ids: &[DocId],
+        num_docs: u32,
+        out: &mut W,
+    ) -> io::Result<()> {
+        if present_doc_ids.len() == num_docs as usize {
+            out.write_all(&[VARIANT_FULL])?;
+        } else {
+            out.write_all(&[VARIANT_OPTIONAL])?;
+            serialize_optional_index(&present_doc_ids, num_docs, out)?;
+        }
+        Ok(())
+    }
+
+    /// Parse a serialized presence section, dispatching on the variant tag.
+    /// `num_docs` is used only when the variant is `Full` — for `Optional`,
+    /// the count is read from the embedded `OptionalIndex` header.
+    pub fn open(file_slice: FileSlice, num_docs: u32) -> io::Result<Presence> {
+        if file_slice.len() == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "presence section is empty",
+            ));
+        }
+        let tag = file_slice.slice(0..1).read_bytes()?[0];
+        let body = file_slice.slice_from(1);
+        match tag {
+            VARIANT_FULL => Ok(Presence::Full { num_docs }),
+            VARIANT_OPTIONAL => Ok(Presence::Optional(open_optional_index(body)?)),
+            other => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unknown presence variant tag: {other}"),
+            )),
+        }
+    }
+
+    /// Number of docs that have a value.
+    pub fn num_non_null(&self) -> u32 {
+        match self {
+            Presence::Full { num_docs } => *num_docs,
+            Presence::Optional(idx) => idx.num_non_nulls(),
+        }
+    }
+
+    /// `true` if `doc_id` has a value.
+    #[inline]
+    pub fn contains(&self, doc_id: DocId) -> bool {
+        match self {
+            Presence::Full { num_docs } => doc_id < *num_docs,
+            Presence::Optional(idx) => Set::contains(idx, doc_id),
+        }
+    }
+
+    /// Returns the dense row id for `doc_id` if it has a value, else `None`.
+    /// For `Full`, this is the identity map — no bitmap consulted.
+    /// Callers must pass a `doc_id` within the segment (`doc_id < max_doc`);
+    /// this is asserted in debug builds.
+    #[inline]
+    pub fn rank_if_exists(&self, doc_id: DocId) -> Option<u32> {
+        match self {
+            Presence::Full { num_docs } => {
+                debug_assert!(doc_id < *num_docs, "doc_id {doc_id} >= num_docs {num_docs}");
+                Some(doc_id)
+            }
+            Presence::Optional(idx) => Set::rank_if_exists(idx, doc_id),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn round_trip(present: &[DocId], num_docs: u32) -> Presence {
+        let mut buf = Vec::new();
+        Presence::serialize(present, num_docs, &mut buf).unwrap();
+        Presence::open(FileSlice::from(buf), num_docs).unwrap()
+    }
+
+    #[test]
+    fn test_all_present_uses_full_variant() {
+        let n = 100u32;
+        let present: Vec<DocId> = (0..n).collect();
+
+        // Wire-level: the serialized output is exactly 1 byte (just the
+        // variant tag); no body — num_docs comes from the caller.
+        let mut buf = Vec::new();
+        Presence::serialize(&present, n, &mut buf).unwrap();
+        assert_eq!(buf.len(), 1, "Full variant should write only the tag");
+        assert_eq!(buf[0], VARIANT_FULL);
+
+        let p = Presence::open(FileSlice::from(buf), n).unwrap();
+        assert!(matches!(p, Presence::Full { num_docs } if num_docs == n));
+        assert_eq!(p.num_non_null(), n);
+        for d in 0..n {
+            assert!(p.contains(d));
+            assert_eq!(p.rank_if_exists(d), Some(d));
+        }
+        // Out-of-range queries are the caller's responsibility:
+        // `contains` returns false, but `rank_if_exists` requires
+        // `doc_id < num_docs` (asserted in debug builds).
+        assert!(!p.contains(n));
+    }
+
+    #[test]
+    fn test_none_present_uses_optional_variant() {
+        let p = round_trip(&[], 100);
+        assert!(matches!(p, Presence::Optional(_)));
+        assert_eq!(p.num_non_null(), 0);
+        for d in 0..100 {
+            assert!(!p.contains(d));
+            assert_eq!(p.rank_if_exists(d), None);
+        }
+    }
+
+    #[test]
+    fn test_sparse_uses_optional_variant() {
+        let present: Vec<DocId> = vec![3, 7, 11, 12, 50, 99];
+        let p = round_trip(&present, 100);
+        assert!(matches!(p, Presence::Optional(_)));
+        assert_eq!(p.num_non_null(), 6);
+        for (row, &doc) in present.iter().enumerate() {
+            assert!(p.contains(doc));
+            assert_eq!(p.rank_if_exists(doc), Some(row as u32));
+        }
+        for d in [0u32, 1, 2, 4, 5, 6, 8, 9, 10, 13, 49, 51, 98] {
+            assert!(!p.contains(d));
+            assert_eq!(p.rank_if_exists(d), None);
+        }
+    }
+
+    #[test]
+    fn test_optional_across_blocks() {
+        // Exercise multiple roaring-style blocks (each spans 64K docs).
+        let n = 1500u32;
+        let present: Vec<DocId> = (0..n).filter(|d| d % 3 == 0).collect();
+        let p = round_trip(&present, n);
+        assert!(matches!(p, Presence::Optional(_)));
+        assert_eq!(p.num_non_null() as usize, present.len());
+        for (row, &doc) in present.iter().enumerate() {
+            assert_eq!(p.rank_if_exists(doc), Some(row as u32));
+        }
+        for d in 0..n {
+            if d % 3 != 0 {
+                assert!(!p.contains(d));
+            }
+        }
+    }
+
+    #[test]
+    fn test_doc_id_beyond_num_docs() {
+        let p = round_trip(&[1, 5], 10);
+        assert!(!p.contains(10));
+        assert!(!p.contains(100));
+        assert_eq!(p.rank_if_exists(10), None);
+    }
+}

--- a/src/vector/flat/reader.rs
+++ b/src/vector/flat/reader.rs
@@ -1,0 +1,143 @@
+//! Reader for the flat vector format.
+//!
+//! Opens the segment's `.flatvec` composite file (one presence section +
+//! one dense row blob per vector field) and hands out per-field
+//! [`FlatVectorColumn`] views for sequential scan.
+
+use std::collections::BTreeMap;
+
+use common::OwnedBytes;
+
+use super::presence::Presence;
+use crate::directory::CompositeFile;
+use crate::index::SegmentComponent;
+use crate::schema::{Field, FieldType, VectorOptions};
+use crate::vector::reader::VectorColumnReader;
+use crate::{DocId, SegmentReader, TantivyError};
+
+pub struct FlatVecReader {
+    composite: CompositeFile,
+    field_options: BTreeMap<Field, VectorOptions>,
+    max_doc: u32,
+}
+
+impl FlatVecReader {
+    pub(crate) fn open(segment_reader: &SegmentReader) -> crate::Result<Self> {
+        let schema = segment_reader.schema();
+        let mut field_options = BTreeMap::new();
+        for (field, entry) in schema.fields() {
+            if let FieldType::Vector(opts) = entry.field_type() {
+                field_options.insert(field, opts.clone());
+            }
+        }
+        let file_slice =
+            segment_reader.open_read(SegmentComponent::Custom(super::FLATVEC_EXT.to_string()))?;
+        Ok(Self {
+            composite: CompositeFile::open(&file_slice)?,
+            field_options,
+            max_doc: segment_reader.max_doc(),
+        })
+    }
+}
+
+impl VectorColumnReader for FlatVecReader {
+    type Column = FlatVectorColumn;
+
+    fn open_column(&self, field: Field) -> crate::Result<FlatVectorColumn> {
+        let options = self.field_options.get(&field).cloned().ok_or_else(|| {
+            TantivyError::InvalidArgument(format!("field {field:?} is not a vector field"))
+        })?;
+        let presence_slice = self.composite.open_read_with_idx(field, 0).ok_or_else(|| {
+            TantivyError::InternalError(format!(
+                "no flat vector data for vector field {field:?} in segment"
+            ))
+        })?;
+        let rows_slice = self.composite.open_read_with_idx(field, 1).ok_or_else(|| {
+            TantivyError::InternalError(format!(
+                "no flat vector data for vector field {field:?} in segment"
+            ))
+        })?;
+        let presence = Presence::open(presence_slice, self.max_doc)?;
+        let row_bytes = rows_slice.read_bytes()?;
+        Ok(FlatVectorColumn {
+            presence,
+            row_bytes,
+            options,
+        })
+    }
+
+    fn count(&self, field: Field) -> crate::Result<usize> {
+        self.field_options.get(&field).ok_or_else(|| {
+            TantivyError::InvalidArgument(format!("field {field:?} is not a vector field"))
+        })?;
+        let presence_slice = self.composite.open_read_with_idx(field, 0).ok_or_else(|| {
+            TantivyError::InternalError(format!(
+                "no flat vector data for vector field {field:?} in segment"
+            ))
+        })?;
+        let presence = Presence::open(presence_slice, self.max_doc)?;
+        Ok(presence.num_non_null() as usize)
+    }
+
+    fn dim(&self, field: Field) -> crate::Result<usize> {
+        self.field_options
+            .get(&field)
+            .map(VectorOptions::dim)
+            .ok_or_else(|| {
+                TantivyError::InvalidArgument(format!("field {field:?} is not a vector field"))
+            })
+    }
+}
+
+/// A view over one vector field's data within a single segment.
+///
+/// Layout:
+/// - `presence`: [`Presence::Full`] for dense columns (no bitmap stored, `row_id == doc_id`) or
+///   [`Presence::Optional`] for sparse columns (rank-supporting bitmap).
+/// - `row_bytes`: dense LE blob, exactly `presence.num_non_null()` rows of the schema dtype.
+///
+/// Lookup is `presence.rank_if_exists(doc) -> row_idx`, then
+/// `&row_bytes[row_idx * bytes_per_vector ..]`. In the `Full` case the rank
+/// step is the identity map — no bitmap consulted.
+pub struct FlatVectorColumn {
+    presence: Presence,
+    row_bytes: OwnedBytes,
+    options: VectorOptions,
+}
+
+impl FlatVectorColumn {
+    pub fn dim(&self) -> usize {
+        self.options.dim()
+    }
+
+    /// Number of docs that actually have a vector value.
+    pub fn len(&self) -> usize {
+        self.presence.num_non_null() as usize
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.presence.num_non_null() == 0
+    }
+
+    /// `true` if `doc_id` has a stored vector.
+    #[inline]
+    pub fn contains(&self, doc_id: DocId) -> bool {
+        self.presence.contains(doc_id)
+    }
+
+    /// Borrow the raw little-endian bytes for a single document.
+    ///
+    /// Returns `None` if `doc_id` has no vector. The returned slice is a
+    /// zero-copy borrow into the column's `OwnedBytes`.
+    #[inline]
+    pub fn vector_bytes_at(&self, doc_id: DocId) -> Option<&[u8]> {
+        let row_id = self.presence.rank_if_exists(doc_id)? as usize;
+        let stride = self.options.bytes_per_vector();
+        let start = row_id * stride;
+        let end = start + stride;
+        if end > self.row_bytes.len() {
+            return None;
+        }
+        Some(&self.row_bytes[start..end])
+    }
+}

--- a/src/vector/flat/tests.rs
+++ b/src/vector/flat/tests.rs
@@ -1,0 +1,446 @@
+use std::ops::Bound;
+
+use crate::collector::TopDocs;
+use crate::index::SegmentId;
+use crate::indexer::NoMergePolicy;
+use crate::query::{AllQuery, Query, RangeQuery, TermQuery};
+use crate::schema::{
+    Field, IndexRecordOption, Metric, Schema, Term, Value, VectorOptions, FAST, INDEXED, STORED,
+    TEXT,
+};
+use crate::vector::VectorColumnReader;
+use crate::{DocAddress, Index, IndexWriter, Score, Searcher, TantivyDocument};
+
+// ---- helpers shared across the metric tests ----
+
+/// Search top-N via vector similarity, with the supplied filter query as
+/// the candidate set.
+fn search_top_n(
+    searcher: &Searcher,
+    query: &dyn Query,
+    vec_field: Field,
+    query_vec: Vec<f32>,
+    k: usize,
+) -> crate::Result<Vec<(Score, DocAddress)>> {
+    searcher.search(
+        query,
+        &TopDocs::with_limit(k).order_by_similarity(vec_field, query_vec),
+    )
+}
+
+/// Scores must come back in descending order.
+fn assert_descending(hits: &[(Score, DocAddress)]) {
+    for w in hits.windows(2) {
+        assert!(
+            w[0].0 >= w[1].0,
+            "scores not descending: {:?} >= {:?}",
+            w[0],
+            w[1],
+        );
+    }
+}
+
+fn score_at(hits: &[(Score, DocAddress)], i: usize) -> Score {
+    hits[i].0
+}
+
+/// Fetch the first stored text value for `field` at `doc_addr`.
+fn stored_text(searcher: &Searcher, field: Field, doc_addr: DocAddress) -> crate::Result<String> {
+    let doc = searcher.doc::<TantivyDocument>(doc_addr)?;
+    Ok(doc
+        .get_first(field)
+        .and_then(|v| Value::as_str(&v))
+        .expect("stored text value")
+        .to_string())
+}
+
+// ---- L2: text filter, single vector field, multi-segment ----
+
+#[test]
+fn test_search_l2() -> crate::Result<()> {
+    let mut schema_builder = Schema::builder();
+    let category = schema_builder.add_text_field("category", TEXT | STORED);
+    let embed = schema_builder.add_vector_field("embedding", VectorOptions::new(3, Metric::L2));
+    let schema = schema_builder.build();
+    let index = Index::create_in_ram(schema);
+
+    let mut writer: IndexWriter = index.writer_with_num_threads(1, 15_000_000)?;
+    writer.set_merge_policy(Box::new(NoMergePolicy));
+
+    // Two segments, six docs total.
+    let batches = [
+        vec![
+            ("alpha", [1.0f32, 0.0, 0.0]),
+            ("alpha", [0.9, 0.1, 0.0]),
+            ("beta", [0.0, 1.0, 0.0]),
+        ],
+        vec![
+            ("beta", [0.0f32, 0.0, 1.0]),
+            ("alpha", [-1.0, 0.0, 0.0]),
+            ("alpha", [0.95, 0.05, 0.0]),
+        ],
+    ];
+    for batch in &batches {
+        for (cat, v) in batch {
+            let mut doc = TantivyDocument::new();
+            doc.add_text(category, cat);
+            doc.add_vector(embed, v);
+            writer.add_document(doc)?;
+        }
+        writer.commit()?;
+    }
+
+    let searcher = index.reader()?.searcher();
+    let query_vec = vec![1.0f32, 0.0, 0.0];
+
+    // Pure vector search: top-3 should all be alpha docs (point along +x).
+    let hits = search_top_n(&searcher, &AllQuery, embed, query_vec.clone(), 3)?;
+    assert_eq!(hits.len(), 3);
+    assert_descending(&hits);
+    // Exact match → -l2² == 0.
+    assert!(score_at(&hits, 0).abs() < 1e-6, "top: {:?}", hits[0].0);
+    for (_, addr) in &hits {
+        assert_eq!(stored_text(&searcher, category, *addr)?, "alpha");
+    }
+
+    // Filtered: only beta docs.
+    let beta = TermQuery::new(
+        Term::from_field_text(category, "beta"),
+        IndexRecordOption::Basic,
+    );
+    let hits = search_top_n(&searcher, &beta, embed, query_vec, 10)?;
+    assert_eq!(hits.len(), 2);
+    assert_descending(&hits);
+    for (_, addr) in &hits {
+        assert_eq!(stored_text(&searcher, category, *addr)?, "beta");
+    }
+
+    Ok(())
+}
+
+// ---- Cosine: u64 range filter, two vector fields of different dim ----
+
+#[test]
+fn test_search_cosine() -> crate::Result<()> {
+    let mut schema_builder = Schema::builder();
+    let group = schema_builder.add_u64_field("group", INDEXED | FAST | STORED);
+    let small = schema_builder.add_vector_field("small", VectorOptions::new(2, Metric::Cosine));
+    let big = schema_builder.add_vector_field("big", VectorOptions::new(4, Metric::Cosine));
+    let schema = schema_builder.build();
+    let index = Index::create_in_ram(schema);
+
+    let mut writer: IndexWriter = index.writer_with_num_threads(1, 15_000_000)?;
+    writer.set_merge_policy(Box::new(NoMergePolicy));
+
+    // (group, small, big) — five docs split across two segments.
+    let docs = [
+        (1u64, [1.0f32, 0.0], [1.0f32, 0.0, 0.0, 0.0]),
+        (1, [0.9, 0.1], [0.9, 0.1, 0.0, 0.0]),
+        (2, [0.0, 1.0], [0.0, 1.0, 0.0, 0.0]),
+        (2, [-1.0, 0.0], [-1.0, 0.0, 0.0, 0.0]),
+        (3, [0.0, -1.0], [0.0, 0.0, 0.0, 1.0]),
+    ];
+    for (i, (g, s, b)) in docs.iter().enumerate() {
+        let mut doc = TantivyDocument::new();
+        doc.add_u64(group, *g);
+        doc.add_vector(small, s);
+        doc.add_vector(big, b);
+        writer.add_document(doc)?;
+        if i == 2 {
+            writer.commit()?;
+        }
+    }
+    writer.commit()?;
+
+    let searcher = index.reader()?.searcher();
+
+    // Pure: closest to [1,0] in the small field — identical doc gets cos=1,
+    // opposite-direction doc gets cos=-1.
+    let hits = search_top_n(&searcher, &AllQuery, small, vec![1.0f32, 0.0], 5)?;
+    assert_eq!(hits.len(), 5);
+    assert_descending(&hits);
+    assert!(
+        (score_at(&hits, 0) - 1.0).abs() < 1e-5,
+        "top: {:?}",
+        hits[0].0
+    );
+    let last = hits.last().unwrap().0;
+    assert!((last + 1.0).abs() < 1e-5);
+
+    // The big field is independently queryable on the same docs.
+    let hits = search_top_n(&searcher, &AllQuery, big, vec![0.0f32, 0.0, 0.0, 1.0], 3)?;
+    assert_descending(&hits);
+    assert!((score_at(&hits, 0) - 1.0).abs() < 1e-5);
+
+    // Filter: group == 2 (one orthogonal + one opposite to query in `small`).
+    let group2 = RangeQuery::new(
+        Bound::Included(Term::from_field_u64(group, 2)),
+        Bound::Included(Term::from_field_u64(group, 2)),
+    );
+    let hits = search_top_n(&searcher, &group2, small, vec![1.0f32, 0.0], 10)?;
+    assert_eq!(hits.len(), 2);
+    assert_descending(&hits);
+    assert!(
+        score_at(&hits, 0).abs() < 1e-5,
+        "orthogonal first: {:?}",
+        hits[0].0
+    );
+    assert!((score_at(&hits, 1) + 1.0).abs() < 1e-5);
+
+    Ok(())
+}
+
+// ---- Dot: bool filter ----
+
+#[test]
+fn test_search_dot() -> crate::Result<()> {
+    let mut schema_builder = Schema::builder();
+    let active = schema_builder.add_bool_field("active", INDEXED | STORED);
+    let embed = schema_builder.add_vector_field("embedding", VectorOptions::new(3, Metric::Dot));
+    let schema = schema_builder.build();
+    let index = Index::create_in_ram(schema);
+
+    let mut writer: IndexWriter = index.writer_with_num_threads(1, 15_000_000)?;
+    writer.set_merge_policy(Box::new(NoMergePolicy));
+
+    // (active, vector) — five docs split across two segments. Dot is
+    // magnitude-sensitive: [2,0,0]·[1,0,0] = 2 beats [1,0,0]·[1,0,0] = 1.
+    let docs = [
+        (true, [1.0f32, 0.0, 0.0]),
+        (true, [2.0, 0.0, 0.0]),
+        (false, [1.0, 0.0, 0.0]),
+        (false, [-1.0, 0.0, 0.0]),
+        (true, [0.0, 1.0, 0.0]),
+    ];
+    for (i, (a, v)) in docs.iter().enumerate() {
+        let mut doc = TantivyDocument::new();
+        doc.add_bool(active, *a);
+        doc.add_vector(embed, v);
+        writer.add_document(doc)?;
+        if i == 2 {
+            writer.commit()?;
+        }
+    }
+    writer.commit()?;
+
+    let searcher = index.reader()?.searcher();
+    let query_vec = vec![1.0f32, 0.0, 0.0];
+
+    // Pure: dot products are 2, 1, 1, 0, -1.
+    let hits = search_top_n(&searcher, &AllQuery, embed, query_vec.clone(), 5)?;
+    assert_eq!(hits.len(), 5);
+    assert_descending(&hits);
+    assert!(
+        (score_at(&hits, 0) - 2.0).abs() < 1e-5,
+        "top: {:?}",
+        hits[0].0
+    );
+    let last = hits.last().unwrap().0;
+    assert!((last + 1.0).abs() < 1e-5);
+
+    // Filtered: only active=true (3 docs: dot=2, dot=1, dot=0).
+    let active_true = TermQuery::new(
+        Term::from_field_bool(active, true),
+        IndexRecordOption::Basic,
+    );
+    let hits = search_top_n(&searcher, &active_true, embed, query_vec, 10)?;
+    assert_eq!(hits.len(), 3);
+    assert_descending(&hits);
+    assert!((score_at(&hits, 0) - 2.0).abs() < 1e-5);
+    assert!(score_at(&hits, 2).abs() < 1e-5);
+
+    Ok(())
+}
+
+// ---- Sparse: not every doc has a vector ----
+
+#[test]
+fn test_search_sparse_vectors() -> crate::Result<()> {
+    let mut schema_builder = Schema::builder();
+    let category = schema_builder.add_text_field("category", TEXT | STORED);
+    let embed = schema_builder.add_vector_field("embedding", VectorOptions::new(3, Metric::L2));
+    let schema = schema_builder.build();
+    let index = Index::create_in_ram(schema);
+
+    let mut writer: IndexWriter = index.writer_with_num_threads(1, 15_000_000)?;
+    writer.set_merge_policy(Box::new(NoMergePolicy));
+
+    // Six docs, only some have a vector.
+    // (category, optional vector)
+    let docs: &[(&str, Option<[f32; 3]>)] = &[
+        ("alpha", Some([1.0, 0.0, 0.0])),
+        ("beta", None), // no embedding
+        ("alpha", Some([0.9, 0.1, 0.0])),
+        ("beta", None), // no embedding
+        ("alpha", Some([-1.0, 0.0, 0.0])),
+        ("gamma", None), // no embedding
+    ];
+    for (cat, v) in docs {
+        let mut doc = TantivyDocument::new();
+        doc.add_text(category, cat);
+        if let Some(v) = v {
+            doc.add_vector(embed, v);
+        }
+        writer.add_document(doc)?;
+    }
+    writer.commit()?;
+
+    let searcher = index.reader()?.searcher();
+    let segments = searcher.segment_readers();
+    assert_eq!(segments.len(), 1);
+
+    // Plugin reader: column reports only 3 present docs out of 6.
+    let vec_reader = crate::vector::VectorReader::open(&segments[0])?;
+    let column = vec_reader.open_column(embed)?;
+    assert_eq!(column.len(), 3);
+    // Present docs: 0, 2, 4
+    for d in [0u32, 2, 4] {
+        assert!(column.contains(d), "doc {d} should be present");
+        assert!(column.vector_bytes_at(d).is_some());
+    }
+    // Absent docs: 1, 3, 5 — bitmap says no, lookup returns None
+    for d in [1u32, 3, 5] {
+        assert!(!column.contains(d), "doc {d} should be absent");
+        assert!(column.vector_bytes_at(d).is_none());
+    }
+
+    // Pure vector search: only the 3 docs with vectors come back —
+    // vectorless docs are dropped (TopDocsByVectorSimilarity contract,
+    // imposed by IVF compatibility).
+    let hits = search_top_n(&searcher, &AllQuery, embed, vec![1.0f32, 0.0, 0.0], 10)?;
+    assert_eq!(hits.len(), 3, "only docs with vectors come back");
+    assert_descending(&hits);
+    // Top hit: exact match -> -l2² == 0
+    assert!(score_at(&hits, 0).abs() < 1e-6);
+
+    // Filtered + sparse: filter to "beta" (which has no vectors).
+    // Empty result — beta docs match the filter but have no vectors.
+    let beta = TermQuery::new(
+        Term::from_field_text(category, "beta"),
+        IndexRecordOption::Basic,
+    );
+    let hits = search_top_n(&searcher, &beta, embed, vec![1.0f32, 0.0, 0.0], 10)?;
+    assert!(
+        hits.is_empty(),
+        "beta docs have no vectors → empty result, got {hits:?}",
+    );
+
+    Ok(())
+}
+
+// ---- Merge with sparse vectors ----
+
+#[test]
+fn test_merge_preserves_sparsity() -> crate::Result<()> {
+    let mut schema_builder = Schema::builder();
+    let category = schema_builder.add_text_field("category", TEXT | STORED);
+    let embed = schema_builder.add_vector_field("embedding", VectorOptions::new(2, Metric::L2));
+    let schema = schema_builder.build();
+    let index = Index::create_in_ram(schema);
+
+    let mut writer: IndexWriter = index.writer_with_num_threads(1, 15_000_000)?;
+    writer.set_merge_policy(Box::new(NoMergePolicy));
+
+    // Segment 1: 2 docs, only the second has a vector.
+    let mut doc = TantivyDocument::new();
+    doc.add_text(category, "no_vec_1");
+    writer.add_document(doc)?;
+    let mut doc = TantivyDocument::new();
+    doc.add_text(category, "has_vec_1");
+    doc.add_vector(embed, &[1.0f32, 0.0]);
+    writer.add_document(doc)?;
+    writer.commit()?;
+
+    // Segment 2: 2 docs, only the first has a vector.
+    let mut doc = TantivyDocument::new();
+    doc.add_text(category, "has_vec_2");
+    doc.add_vector(embed, &[0.0f32, 1.0]);
+    writer.add_document(doc)?;
+    let mut doc = TantivyDocument::new();
+    doc.add_text(category, "no_vec_2");
+    writer.add_document(doc)?;
+    writer.commit()?;
+
+    // Merge.
+    let segment_ids: Vec<SegmentId> = index.searchable_segment_ids()?.into_iter().collect();
+    assert_eq!(segment_ids.len(), 2);
+    writer.merge(&segment_ids).wait()?;
+    writer.wait_merging_threads()?;
+
+    // After merge: 4 docs in one segment, exactly 2 have vectors.
+    let searcher = index.reader()?.searcher();
+    let segments = searcher.segment_readers();
+    assert_eq!(segments.len(), 1);
+    assert_eq!(segments[0].max_doc(), 4);
+    let vec_reader = crate::vector::VectorReader::open(&segments[0])?;
+    let column = vec_reader.open_column(embed)?;
+    assert_eq!(column.len(), 2, "two vectors should survive the merge");
+    let present: Vec<u32> = (0..4).filter(|&d| column.contains(d)).collect();
+    assert_eq!(present.len(), 2);
+    Ok(())
+}
+
+// ---- Merge ----
+
+#[test]
+fn test_flat_vec_plugin_merge() -> crate::Result<()> {
+    let mut schema_builder = Schema::builder();
+    let text_field = schema_builder.add_text_field("text", TEXT | STORED);
+    let vec_field = schema_builder.add_vector_field("embedding", VectorOptions::new(4, Metric::L2));
+    let schema = schema_builder.build();
+    let index = Index::create_in_ram(schema);
+
+    let mut writer: IndexWriter = index.writer_with_num_threads(1, 15_000_000)?;
+    writer.set_merge_policy(Box::new(NoMergePolicy));
+
+    let mut doc = TantivyDocument::new();
+    doc.add_text(text_field, "a");
+    doc.add_vector(vec_field, &[1.0, 2.0, 3.0, 4.0]);
+    writer.add_document(doc)?;
+    writer.commit()?;
+
+    let mut doc = TantivyDocument::new();
+    doc.add_text(text_field, "b");
+    doc.add_vector(vec_field, &[5.0, 6.0, 7.0, 8.0]);
+    writer.add_document(doc)?;
+
+    let mut doc = TantivyDocument::new();
+    doc.add_text(text_field, "c");
+    doc.add_vector(vec_field, &[9.0, 10.0, 11.0, 12.0]);
+    writer.add_document(doc)?;
+    writer.commit()?;
+
+    let segment_ids: Vec<SegmentId> = index.searchable_segment_ids()?.into_iter().collect();
+    assert_eq!(segment_ids.len(), 2);
+    writer.merge(&segment_ids).wait()?;
+    writer.wait_merging_threads()?;
+
+    let reader = index.reader()?;
+    let searcher = reader.searcher();
+    let segments = searcher.segment_readers();
+    assert_eq!(segments.len(), 1);
+
+    let vec_reader = crate::vector::VectorReader::open(&segments[0])?;
+    let column = vec_reader.open_column(vec_field)?;
+
+    let decode = |bytes: &[u8]| -> Vec<f32> {
+        bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()
+    };
+
+    let mut got: Vec<Vec<f32>> = (0..segments[0].max_doc())
+        .filter_map(|d| column.vector_bytes_at(d).map(decode))
+        .collect();
+    got.sort_by(|a, b| a[0].partial_cmp(&b[0]).unwrap());
+    assert_eq!(
+        got,
+        vec![
+            vec![1.0, 2.0, 3.0, 4.0],
+            vec![5.0, 6.0, 7.0, 8.0],
+            vec![9.0, 10.0, 11.0, 12.0],
+        ]
+    );
+    Ok(())
+}

--- a/src/vector/flat/writer.rs
+++ b/src/vector/flat/writer.rs
@@ -1,0 +1,186 @@
+use std::any::Any;
+use std::collections::BTreeMap;
+use std::io::Write;
+
+use common::TerminatingWrite;
+
+use super::presence::Presence;
+use crate::directory::CompositeWrite;
+use crate::index::{Segment, SegmentComponent};
+use crate::indexer::doc_id_mapping::DocIdMapping;
+use crate::plugin::PluginWriter;
+use crate::schema::document::{TantivyDocument, Value};
+use crate::schema::{Field, FieldType, Schema};
+use crate::vector::meta::{VectorStorageFormat, VECMETA_EXT};
+use crate::{DocId, TantivyError};
+
+/// Per-field in-memory state: the doc ids that have a value (ascending),
+/// plus a dense byte array — analogous to fast-fields' `Optional`
+/// cardinality. Docs without a vector occupy zero bytes of storage.
+///
+/// Rows are kept as raw little-endian bytes rather than decoded `T`
+/// values. The bytes go in via `add_document` and come back out at
+/// serialize time unchanged — no decode/re-encode round-trip, no
+/// dependency on `T: VectorElement` in the writer.
+struct FieldBuffer {
+    /// Doc ids that have a value for this field, in insertion order
+    /// (which equals ascending old-doc-id order since `add_document<D>`
+    /// is called sequentially).
+    present_doc_ids: Vec<DocId>,
+    /// Dense byte blob: `row_bytes[i*stride..(i+1)*stride]` is the
+    /// vector for `present_doc_ids[i]`.
+    row_bytes: Vec<u8>,
+    /// Bytes per vector (`dim * dtype.size_bytes()`).
+    stride: usize,
+}
+
+impl FieldBuffer {
+    fn push_bytes(&mut self, doc_id: DocId, bytes: &[u8]) {
+        debug_assert_eq!(bytes.len(), self.stride);
+        self.present_doc_ids.push(doc_id);
+        self.row_bytes.extend_from_slice(bytes);
+    }
+
+    fn mem_usage(&self) -> usize {
+        std::mem::size_of::<Self>()
+            + self.present_doc_ids.capacity() * std::mem::size_of::<DocId>()
+            + self.row_bytes.capacity()
+    }
+}
+
+pub struct FlatVecWriter {
+    fields: BTreeMap<Field, FieldBuffer>,
+    /// Set by [`SegmentWriter::finalize`] before [`serialize`]. Used to
+    /// size the presence bitmap.
+    num_docs: DocId,
+}
+
+impl FlatVecWriter {
+    pub fn for_schema(schema: &Schema) -> Self {
+        let mut fields = BTreeMap::new();
+        for (field, entry) in schema.fields() {
+            if let FieldType::Vector(opts) = entry.field_type() {
+                fields.insert(
+                    field,
+                    FieldBuffer {
+                        present_doc_ids: Vec::new(),
+                        row_bytes: Vec::new(),
+                        stride: opts.bytes_per_vector(),
+                    },
+                );
+            }
+        }
+        Self {
+            fields,
+            num_docs: 0,
+        }
+    }
+}
+
+impl PluginWriter for FlatVecWriter {
+    fn add_document(
+        &mut self,
+        doc_id: DocId,
+        doc: &TantivyDocument,
+        schema: &Schema,
+    ) -> crate::Result<()> {
+        if self.fields.is_empty() {
+            return Ok(());
+        }
+        self.num_docs = doc_id + 1;
+        for (field, buf) in self.fields.iter_mut() {
+            let value = match doc.get_first(*field) {
+                Some(value) => value,
+                None => continue,
+            };
+            let bytes = value.as_value().as_bytes().ok_or_else(|| {
+                TantivyError::SchemaError(format!(
+                    "Expected vector bytes for field {:?}",
+                    schema.get_field_entry(*field).name()
+                ))
+            })?;
+            if bytes.len() != buf.stride {
+                return Err(TantivyError::SchemaError(format!(
+                    "vector byte length mismatch for field {:?}: expected {} bytes, got {}",
+                    schema.get_field_entry(*field).name(),
+                    buf.stride,
+                    bytes.len(),
+                )));
+            }
+            buf.push_bytes(doc_id, bytes);
+        }
+        Ok(())
+    }
+    fn serialize(
+        &mut self,
+        segment: &Segment,
+        doc_id_map: Option<&DocIdMapping>,
+    ) -> crate::Result<()> {
+        if self.fields.is_empty() {
+            return Ok(());
+        }
+        let mut meta_write =
+            segment.open_write(SegmentComponent::Custom(VECMETA_EXT.to_string()))?;
+        VectorStorageFormat::Flat.serialize(&mut meta_write)?;
+        meta_write.terminate()?;
+
+        let write = segment.open_write(SegmentComponent::Custom(super::FLATVEC_EXT.to_string()))?;
+        let mut composite = CompositeWrite::wrap(write);
+
+        for (field, buf) in &self.fields {
+            // Compute (present, row_bytes) in target doc-id order. For
+            // the no-remap case the writer already accumulates in
+            // ascending insertion (= target) order.
+            let (present, row_bytes): (Vec<DocId>, Vec<u8>) = if let Some(map) = doc_id_map {
+                let mut p = Vec::new();
+                let mut r = Vec::new();
+                for new_doc_id in 0..map.num_new_doc_ids() as DocId {
+                    let old_doc_id = map.get_old_doc_id(new_doc_id);
+                    if let Ok(row_idx) = buf.present_doc_ids.binary_search(&old_doc_id) {
+                        p.push(new_doc_id);
+                        let start = row_idx * buf.stride;
+                        r.extend_from_slice(&buf.row_bytes[start..start + buf.stride]);
+                    }
+                }
+                (p, r)
+            } else {
+                (buf.present_doc_ids.clone(), buf.row_bytes.clone())
+            };
+
+            // Slice (field, 0): presence section. Picks Full if every
+            // doc is present (typical for dense embeddings, just one
+            // tag byte) or Optional otherwise.
+            let bitmap_w = composite.for_field_with_idx(*field, 0);
+            Presence::serialize(&present, self.num_docs, bitmap_w)?;
+            bitmap_w.flush()?;
+
+            // Slice (field, 1): dense LE byte rows, one per present doc.
+            let rows_w = composite.for_field_with_idx(*field, 1);
+            rows_w.write_all(&row_bytes)?;
+            rows_w.flush()?;
+        }
+        composite.close()?;
+        Ok(())
+    }
+
+    fn close(self: Box<Self>) -> crate::Result<()> {
+        Ok(())
+    }
+
+    fn mem_usage(&self) -> usize {
+        std::mem::size_of::<Self>()
+            + self
+                .fields
+                .values()
+                .map(FieldBuffer::mem_usage)
+                .sum::<usize>()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}

--- a/src/vector/meta.rs
+++ b/src/vector/meta.rs
@@ -1,0 +1,58 @@
+use std::io::{self, Write};
+
+use common::HasLen;
+
+use crate::directory::FileSlice;
+
+pub(crate) const VECMETA_EXT: &str = "vecmeta";
+
+const FORMAT_FLAT: u8 = 0;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum VectorStorageFormat {
+    Flat,
+}
+
+impl VectorStorageFormat {
+    pub(crate) fn serialize<W: Write + ?Sized>(self, writer: &mut W) -> io::Result<()> {
+        let code = match self {
+            Self::Flat => FORMAT_FLAT,
+        };
+        writer.write_all(&[code])
+    }
+
+    fn from_code(code: u8) -> io::Result<Self> {
+        match code {
+            FORMAT_FLAT => Ok(Self::Flat),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unsupported vector storage format",
+            )),
+        }
+    }
+}
+
+pub(crate) struct VectorSegmentMeta {
+    pub(crate) format: VectorStorageFormat,
+    pub(crate) payload: FileSlice,
+}
+
+impl VectorSegmentMeta {
+    pub(crate) fn open(file_slice: FileSlice) -> io::Result<Self> {
+        if file_slice.len() == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "vector metadata is empty",
+            ));
+        }
+        let format = VectorStorageFormat::from_code(file_slice.slice(0..1).read_bytes()?[0])?;
+        let payload = file_slice.slice_from(1);
+        if format == VectorStorageFormat::Flat && payload.len() != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "flat vector metadata has trailing bytes",
+            ));
+        }
+        Ok(Self { format, payload })
+    }
+}

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -1,6 +1,30 @@
+//! Distance kernels, the vector element trait, and the per-segment storage plugin.
+//!
+//! The schema-level field configuration ([`VectorOptions`](crate::schema::VectorOptions),
+//! [`Metric`](crate::schema::Metric), [`VectorDType`]) lives in the schema module; the
+//! element trait [`VectorElement`] and the distance kernels live here. The on-disk format
+//! lives in the [`flat`] submodule (dense full-precision layout), owned by the
+//! [`VectorPlugin`]. Top-N vector queries dispatch over it via [`VectorBackend`].
+
 use std::io;
 
 use crate::schema::VectorDType;
+
+mod backend;
+mod collector;
+mod distance;
+mod meta;
+mod plugin;
+mod reader;
+
+pub mod flat;
+
+pub use backend::VectorBackend;
+pub use collector::TopDocsByVectorSimilarity;
+pub use distance::{cosine, cosine_bytes, dot, dot_bytes, l2_squared, l2_squared_bytes};
+pub use flat::{FlatVecReader, FlatVecWriter, FlatVectorColumn};
+pub use plugin::VectorPlugin;
+pub use reader::{VectorColumn, VectorColumnReader, VectorReader};
 
 /// A vector element type with the primitives needed by the storage
 /// layer and the distance kernels.

--- a/src/vector/plugin.rs
+++ b/src/vector/plugin.rs
@@ -1,0 +1,28 @@
+//! Vector storage plugin.
+//!
+//! [`VectorPlugin`] owns per-segment vector storage end-to-end:
+//! - During indexing, accumulates raw vector bytes per doc and writes flat `.vecmeta` and
+//!   `.flatvec` files at segment finalize.
+//! - During merge, copies vectors forward into flat `.vecmeta` and `.flatvec`.
+//! - During reads, [`VectorReader`](super::reader::VectorReader) uses the segment-level `.vecmeta`
+//!   marker to open the storage format.
+
+use super::flat::{merge_flat, FlatVecWriter, FLATVEC_EXT};
+use super::meta::VECMETA_EXT;
+use crate::plugin::{PluginMergeContext, PluginWriter, PluginWriterContext, SegmentPlugin};
+
+pub struct VectorPlugin;
+
+impl SegmentPlugin for VectorPlugin {
+    fn extensions(&self) -> &[&str] {
+        &[FLATVEC_EXT, VECMETA_EXT]
+    }
+
+    fn create_writer(&self, ctx: &PluginWriterContext) -> crate::Result<Box<dyn PluginWriter>> {
+        Ok(Box::new(FlatVecWriter::for_schema(&ctx.segment.schema())))
+    }
+
+    fn merge(&self, ctx: PluginMergeContext) -> crate::Result<()> {
+        merge_flat(&ctx)
+    }
+}

--- a/src/vector/reader.rs
+++ b/src/vector/reader.rs
@@ -1,0 +1,141 @@
+//! Per-segment vector storage dispatch.
+//!
+//! Reads the segment's `.vecmeta` to learn which storage format was written,
+//! opens the matching reader, and exposes a field's column via
+//! [`VectorColumnReader::open_column`].
+
+use std::collections::BTreeMap;
+
+use super::flat::{FlatVecReader, FlatVectorColumn};
+use super::meta::{VectorSegmentMeta, VectorStorageFormat, VECMETA_EXT};
+use crate::directory::error::OpenReadError;
+use crate::index::SegmentComponent;
+use crate::schema::{Field, FieldType};
+use crate::{DocId, SegmentReader, TantivyError};
+
+pub trait VectorColumnReader {
+    type Column;
+
+    fn open_column(&self, field: Field) -> crate::Result<Self::Column>;
+
+    fn count(&self, field: Field) -> crate::Result<usize>;
+
+    fn dim(&self, field: Field) -> crate::Result<usize>;
+}
+
+pub struct VectorReader {
+    storage: VectorStorageReader,
+    vector_dims: BTreeMap<Field, usize>,
+}
+
+enum VectorStorageReader {
+    None,
+    Flat(FlatVecReader),
+}
+
+impl VectorReader {
+    pub(crate) fn open(segment_reader: &SegmentReader) -> crate::Result<Self> {
+        let schema = segment_reader.schema();
+        let mut vector_dims = BTreeMap::new();
+        for (field, entry) in schema.fields() {
+            if let FieldType::Vector(opts) = entry.field_type() {
+                vector_dims.insert(field, opts.dim());
+            }
+        }
+        let meta_slice =
+            match segment_reader.open_read(SegmentComponent::Custom(VECMETA_EXT.to_string())) {
+                Ok(file_slice) => Some(file_slice),
+                Err(OpenReadError::FileDoesNotExist(_)) => None,
+                Err(err) => return Err(err.into()),
+            };
+        let storage = if let Some(file_slice) = meta_slice {
+            let meta = VectorSegmentMeta::open(file_slice)?;
+            let _payload = meta.payload;
+            match meta.format {
+                VectorStorageFormat::Flat => {
+                    VectorStorageReader::Flat(FlatVecReader::open(segment_reader)?)
+                }
+            }
+        } else {
+            VectorStorageReader::None
+        };
+        Ok(Self {
+            storage,
+            vector_dims,
+        })
+    }
+}
+
+impl VectorColumnReader for VectorReader {
+    type Column = VectorColumn;
+
+    fn open_column(&self, field: Field) -> crate::Result<VectorColumn> {
+        if !self.vector_dims.contains_key(&field) {
+            return Err(TantivyError::InvalidArgument(format!(
+                "field {field:?} is not a vector field"
+            )));
+        }
+        match &self.storage {
+            VectorStorageReader::Flat(reader) => reader.open_column(field).map(VectorColumn::Flat),
+            VectorStorageReader::None => Err(TantivyError::InternalError(format!(
+                "no vector data for vector field {field:?} in segment"
+            ))),
+        }
+    }
+
+    fn count(&self, field: Field) -> crate::Result<usize> {
+        if !self.vector_dims.contains_key(&field) {
+            return Err(TantivyError::InvalidArgument(format!(
+                "field {field:?} is not a vector field"
+            )));
+        }
+        match &self.storage {
+            VectorStorageReader::Flat(reader) => reader.count(field),
+            VectorStorageReader::None => Err(TantivyError::InternalError(format!(
+                "no vector data for vector field {field:?} in segment"
+            ))),
+        }
+    }
+
+    fn dim(&self, field: Field) -> crate::Result<usize> {
+        self.vector_dims.get(&field).copied().ok_or_else(|| {
+            TantivyError::InvalidArgument(format!("field {field:?} is not a vector field"))
+        })
+    }
+}
+
+pub enum VectorColumn {
+    Flat(FlatVectorColumn),
+}
+
+impl VectorColumn {
+    pub fn dim(&self) -> usize {
+        match self {
+            Self::Flat(column) => column.dim(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Flat(column) => column.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Flat(column) => column.is_empty(),
+        }
+    }
+
+    pub fn contains(&self, doc_id: DocId) -> bool {
+        match self {
+            Self::Flat(column) => column.contains(doc_id),
+        }
+    }
+
+    pub fn vector_bytes_at(&self, doc_id: DocId) -> Option<&[u8]> {
+        match self {
+            Self::Flat(column) => column.vector_bytes_at(doc_id),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Second half of the vector-search stack. Fills in the skeleton from #142 with the real on-disk format, registers `VectorPlugin` in `Index::default_plugins`, and wires `SegmentWriter` to feed per-doc vector bytes. After this lands, every merge below the clustering threshold produces a real `.flatvec` file and the search-side flat backend serves the top-N scan.

IVF stays a `todo!()` in `merge_ivf` and a `None`-returning stub on the reader — opting into clustering by lowering `IndexSettings::vector_clustering_threshold` will trigger the `todo!()`. Default stays `usize::MAX`, so every merge stays on the flat branch.

Stacked on top of #142 — review/merge that one first.

## Storage layout

Per segment, multiplexed across fields via a `CompositeFile` under `.flatvec`:

- **Slice (field, 0)**: presence section. `Presence::Full` skips the bitmap entirely for dense columns (the embedding-typical case) — `row_id == doc_id` is the identity map. `Presence::Optional` delegates to columnar's `OptionalIndex` for sparse columns.
- **Slice (field, 1)**: dense little-endian row bytes, exactly `presence.num_non_null()` rows of `dim * dtype.size_bytes()` each.

Lookup: `presence.rank_if_exists(doc) -> row_idx`, then `&row_bytes[row_idx * stride ..]`. Zero-copy borrow into the directory's backing storage (mmap page cache for `MmapDirectory`, refcounted blob for `RamDirectory`).

## Plugin wiring

- `VectorPlugin` registered in `Index::default_plugins` so every index carries vector storage by default.
- `SegmentWriter::add_document` feeds vector-typed fields to `FlatVecWriter`, parallel to how `FastFieldsWriter` is fed.
- `SegmentWriter::finalize` sets `num_docs` on the writer before serialize so the presence bitmap can be sized correctly.
- `merge_flat` walks the doc-id mapping, copies bytes for docs whose source segment had a value, and rebuilds the per-field presence/rows pair into the merge target.

## Backend

`FlatBackend::top_n` walks the filter `DocSet` in ascending doc order via `for_each_no_score`, scoring each surviving doc against the query via `metric.similarity_bytes`. Uses the fast `TopNComputer::push` path (strict-greater short-circuit valid under ascending-D pushes).

## Other

- Flat module-level test suite: e2e indexing/search, merge, presence cardinality dispatch, sort-by-field.
- Columnar re-export of `serialize_optional_index` that the presence section uses directly.

## Test plan

- [x] `cargo check --all-targets` clean
- [x] `cargo test --lib` — 1157 passed, 0 failed