### PR TITLE
fix: Replace sentinel value calculation with something correct.

### DIFF
--- a/src/aggregation/accessor_helpers.rs
+++ b/src/aggregation/accessor_helpers.rs
@@ -16,15 +16,22 @@ use crate::index::SegmentReader;
 /// That way we can use it the same way as if it would come from the fastfield.
 pub(crate) fn get_missing_val_as_u64_lenient(
     column_type: ColumnType,
-    column_val_count: u32,
+    column_max_value: u64,
+    column_value_count: u64,
     missing: &Key,
     field_name: &str,
 ) -> crate::Result<Option<u64>> {
     let missing_val = match missing {
         Key::Str(_) | Key::F64(_) | Key::U64(_) | Key::I64(_) if column_type == ColumnType::Str => {
-            // For strings, we use the max term ordinal + 1, which happens to always be the same as
-            // the number of values in the column
-            Some(column_val_count as u64)
+            // For strings, we use the max term ordinal + 1. If the column has >0 non-nil values,
+            // then we can get the correct max term ordinal from the max column value. However, when
+            // the column has no non-nil values, the max column value defaults to 0, which is
+            // actually the sentinel value we want to use, so we must specify that directly
+            if column_value_count > 0 {
+                Some(column_max_value + 1)
+            } else {
+                Some(0)
+            }
         }
         Key::F64(val) if column_type.numerical_type().is_some() => {
             f64_to_fastfield_u64(*val, &column_type)

--- a/src/aggregation/accessor_helpers.rs
+++ b/src/aggregation/accessor_helpers.rs
@@ -28,7 +28,11 @@ pub(crate) fn get_missing_val_as_u64_lenient(
             // the column has no non-nil values, the max column value defaults to 0, which is
             // actually the sentinel value we want to use, so we must specify that directly
             if column_value_count > 0 {
-                Some(column_max_value + 1)
+                Some(
+                    column_max_value
+                        .checked_add(1)
+                        .expect("This is a u64; we should never be anywhere close to overflowing"),
+                )
             } else {
                 Some(0)
             }

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -879,7 +879,13 @@ fn build_terms_or_cardinality_nodes(
         let missing_value_for_accessor = if use_special_missing_agg {
             None
         } else if let Some(m) = missing.as_ref() {
-            get_missing_val_as_u64_lenient(column_type, accessor.values.num_vals(), m, field_name)?
+            get_missing_val_as_u64_lenient(
+                column_type,
+                accessor.max_value(),
+                accessor.values.num_vals() as u64,
+                m,
+                field_name,
+            )?
         } else {
             None
         };

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -2926,6 +2926,10 @@ mod tests {
                 id_field => i,
                 title_field => title,
             ))?;
+            writer.add_document(doc!(
+                id_field => i + n,
+                title_field => title,
+            ))?;
         }
 
         writer.commit()?;


### PR DESCRIPTION
I was mistaken that `num_vals` is the number of distinct non-nil terms in a column. It is instead the number of "values" in that column, non-distinct. I've modified the agg missing sentinel tests to to include docs with duplicate terms to exhibit this behavior.

The fix is then to use `accessor.max_value()` as before, in combination with `accessor.values.num_vals()` to handle the 0-values case.