### PR TITLE
Expose date_histogram->histogram to external crates

### DIFF
--- a/src/aggregation/bucket/histogram/date_histogram.rs
+++ b/src/aggregation/bucket/histogram/date_histogram.rs
@@ -117,7 +117,7 @@ pub struct DateHistogramAggregationReq {
 }
 
 impl DateHistogramAggregationReq {
-    pub(crate) fn to_histogram_req(&self) -> crate::Result<HistogramAggregation> {
+    pub fn to_histogram_req(&self) -> crate::Result<HistogramAggregation> {
         self.validate()?;
         Ok(HistogramAggregation {
             field: self.field.to_string(),


### PR DESCRIPTION
As part of supporting all postgres datetimes in ParadeDb, we need to rewrite `date_histogram` requests to regular `histogram` requests. Exposing this helper saves duplicating conversion logic that is not specific to the situation we are converting in.