### PR TITLE
fix: `cargo bench` and `fmt` failure in CI

### DIFF
--- a/benches/merge_segments.rs
+++ b/benches/merge_segments.rs
@@ -99,7 +99,10 @@ impl Directory for NullDirectory {
         Ok(true)
     }
 
-    fn open_write_inner(&self, path: &Path) -> Result<Box<dyn TerminatingWrite>, OpenWriteError> {
+    fn open_write_inner(
+        &self,
+        path: &Path,
+    ) -> Result<Box<dyn TerminatingWrite + Send + Sync>, OpenWriteError> {
         let path_buf = path.to_path_buf();
         if path.to_string_lossy().ends_with(".fieldnorm") {
             let writer = InMemoryWriter {

--- a/columnar/src/column_values/u128_based/compact_space/mod.rs
+++ b/columnar/src/column_values/u128_based/compact_space/mod.rs
@@ -529,13 +529,13 @@ impl CompactSpaceDecompressor {
 #[cfg(test)]
 mod tests {
 
+    use common::file_slice::FileSlice;
     use itertools::Itertools;
     use proptest::prelude::*;
 
     use super::*;
     use crate::column_values::u128_based::U128Header;
     use crate::column_values::{open_u128_mapped, serialize_column_values_u128};
-    use common::file_slice::FileSlice;
 
     #[test]
     fn compact_space_test() {

--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -11,7 +11,7 @@ use log::Level;
 use crate::directory::directory_lock::Lock;
 use crate::directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError};
 use crate::directory::{
-    FileHandle, FileSlice, TerminatingWrite, WatchCallback, WatchHandle, WritePtr, InnerWritePtr
+    FileHandle, FileSlice, InnerWritePtr, TerminatingWrite, WatchCallback, WatchHandle, WritePtr,
 };
 use crate::index::SegmentMetaInventory;
 use crate::IndexMeta;

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -11,8 +11,8 @@ use crate::core::MANAGED_FILEPATH;
 use crate::directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError};
 use crate::directory::footer::{Footer, FooterProxy, FOOTER_LEN};
 use crate::directory::{
-    DirectoryLock, DirectoryPanicHandler, FileHandle, FileSlice, GarbageCollectionResult, Lock,
-    WatchCallback, WatchHandle, MANAGED_LOCK, META_LOCK, InnerWritePtr
+    DirectoryLock, DirectoryPanicHandler, FileHandle, FileSlice, GarbageCollectionResult,
+    InnerWritePtr, Lock, WatchCallback, WatchHandle, MANAGED_LOCK, META_LOCK,
 };
 use crate::error::DataCorruption;
 use crate::index::SegmentMetaInventory;
@@ -310,10 +310,7 @@ impl Directory for ManagedDirectory {
         Ok(reader)
     }
 
-    fn open_write_inner(
-        &self,
-        path: &Path,
-    ) -> result::Result<InnerWritePtr, OpenWriteError> {
+    fn open_write_inner(&self, path: &Path) -> result::Result<InnerWritePtr, OpenWriteError> {
         self.register_file_as_managed(path)
             .map_err(|io_error| OpenWriteError::wrap_io_error(io_error, path.to_path_buf()))?;
         Ok(Box::new(FooterProxy::new(

--- a/src/directory/mmap_directory/mod.rs
+++ b/src/directory/mmap_directory/mod.rs
@@ -22,8 +22,8 @@ use crate::directory::error::{
     DeleteError, LockError, OpenDirectoryError, OpenReadError, OpenWriteError,
 };
 use crate::directory::{
-    AntiCallToken, Directory, DirectoryLock, FileHandle, Lock, OwnedBytes, TerminatingWrite,
-    WatchCallback, WatchHandle, InnerWritePtr
+    AntiCallToken, Directory, DirectoryLock, FileHandle, InnerWritePtr, Lock, OwnedBytes,
+    TerminatingWrite, WatchCallback, WatchHandle,
 };
 
 pub type ArcBytes = Arc<dyn Deref<Target = [u8]> + Send + Sync + 'static>;

--- a/src/directory/ram_directory.rs
+++ b/src/directory/ram_directory.rs
@@ -10,8 +10,8 @@ use super::FileHandle;
 use crate::core::META_FILEPATH;
 use crate::directory::error::{DeleteError, OpenReadError, OpenWriteError};
 use crate::directory::{
-    AntiCallToken, Directory, FileSlice, TerminatingWrite, WatchCallback, WatchCallbackList,
-    WatchHandle, InnerWritePtr
+    AntiCallToken, Directory, FileSlice, InnerWritePtr, TerminatingWrite, WatchCallback,
+    WatchCallbackList, WatchHandle,
 };
 
 /// Writer associated with the [`RamDirectory`].

--- a/sstable/src/lib.rs
+++ b/sstable/src/lib.rs
@@ -49,9 +49,8 @@ pub mod streamer;
 pub mod value;
 
 mod index;
-pub use index::{BlockAddr, SSTableIndex, SSTableIndexBuilder};
-
 pub use batch::{BatchedTermInfoIter, SortedTermSlice, sort_and_dedupe_terms};
+pub use index::{BlockAddr, SSTableIndex, SSTableIndexBuilder};
 
 pub(crate) mod vint;
 pub use dictionary::{Dictionary, TermOrdHit};


### PR DESCRIPTION
## Summary

`Directory::open_write_inner` returns `InnerWritePtr` (= `Box<dyn TerminatingWrite + Send + Sync>`), but the `merge_segments` benchmark's `NullDirectory` still implemented it returning a bare `Box<dyn TerminatingWrite>` (no `Send + Sync`). This breaks the nightly bench CI job:

```
cargo +nightly bench --no-run --profile=dev --all-features
error[E0053]: method `open_write_inner` has an incompatible type for trait
  --> benches/merge_segments.rs:102:5
```

The writers it returns (`InMemoryWriter`, `NullWriter`) are already `Send + Sync`, so this is purely a return-type annotation fix.

## Testing

`cargo +nightly bench --no-run --profile=dev --all-features` → Finished (verified locally).