### PR TITLE
feat: IvfClusterer trait

### DIFF
--- a/src/index/index.rs
+++ b/src/index/index.rs
@@ -30,7 +30,7 @@ use crate::schema::document::Document;
 use crate::schema::{Field, FieldType, Schema, Type};
 use crate::store::StorePlugin;
 use crate::tokenizer::{TextAnalyzer, TokenizerManager};
-use crate::vector::VectorPlugin;
+use crate::vector::{IvfClusterer, VectorPlugin};
 use crate::SegmentReader;
 
 fn load_metas(
@@ -172,6 +172,7 @@ pub struct IndexBuilder {
     tokenizer_manager: TokenizerManager,
     fast_field_tokenizer_manager: TokenizerManager,
     custom_plugins: Vec<Arc<dyn SegmentPlugin>>,
+    ivf_clusterer: Option<Arc<dyn IvfClusterer>>,
 }
 impl Default for IndexBuilder {
     fn default() -> Self {
@@ -187,6 +188,7 @@ impl IndexBuilder {
             tokenizer_manager: TokenizerManager::default(),
             fast_field_tokenizer_manager: TokenizerManager::default(),
             custom_plugins: Vec::new(),
+            ivf_clusterer: None,
         }
     }
 
@@ -219,6 +221,13 @@ impl IndexBuilder {
     #[must_use]
     pub fn register_plugin(mut self, plugin: Arc<dyn SegmentPlugin>) -> Self {
         self.custom_plugins.push(plugin);
+        self
+    }
+
+    /// Configure the clusterer used when vector merges cross the IVF threshold.
+    #[must_use]
+    pub fn ivf_clusterer(mut self, clusterer: Arc<dyn IvfClusterer>) -> Self {
+        self.ivf_clusterer = Some(clusterer);
         self
     }
 
@@ -297,6 +306,9 @@ impl IndexBuilder {
         index.set_tokenizers(self.tokenizer_manager.clone());
         if index.schema() == self.get_expect_schema()? {
             index.custom_plugins.extend(self.custom_plugins);
+            if let Some(clusterer) = self.ivf_clusterer {
+                index.set_ivf_clusterer(clusterer);
+            }
             Ok(index)
         } else {
             Err(TantivyError::SchemaError(
@@ -365,6 +377,9 @@ impl IndexBuilder {
         index.set_tokenizers(self.tokenizer_manager);
         index.set_fast_field_tokenizers(self.fast_field_tokenizer_manager);
         index.custom_plugins.extend(self.custom_plugins);
+        if let Some(clusterer) = self.ivf_clusterer {
+            index.set_ivf_clusterer(clusterer);
+        }
         Ok(index)
     }
 }
@@ -453,6 +468,7 @@ pub struct Index {
     fast_field_tokenizers: TokenizerManager,
     inventory: SegmentMetaInventory,
     custom_plugins: Vec<Arc<dyn SegmentPlugin>>,
+    ivf_clusterer: Option<Arc<dyn IvfClusterer>>,
 }
 
 impl Index {
@@ -573,6 +589,7 @@ impl Index {
             executor: Executor::single_thread(),
             inventory,
             custom_plugins: Vec::new(),
+            ivf_clusterer: None,
         }
     }
 
@@ -845,6 +862,17 @@ impl Index {
     /// Accessor to the index settings
     pub fn settings_mut(&mut self) -> &mut IndexSettings {
         &mut self.settings
+    }
+
+    /// Configure the clusterer used when vector merges cross the IVF threshold.
+    pub fn set_ivf_clusterer(&mut self, clusterer: Arc<dyn IvfClusterer>) {
+        self.ivf_clusterer = Some(clusterer);
+    }
+
+    // Consumed by the IVF merge routine, which lands with the IVF storage format.
+    #[allow(dead_code)]
+    pub(crate) fn ivf_clusterer(&self) -> Option<&dyn IvfClusterer> {
+        self.ivf_clusterer.as_deref()
     }
 
     /// Accessor to the index schema

--- a/src/index/index_meta.rs
+++ b/src/index/index_meta.rs
@@ -305,6 +305,16 @@ pub struct IndexSettings {
     #[serde(default = "default_codec_types")]
     #[serde(skip_serializing_if = "is_default_codec_types")]
     pub codec_types: Vec<columnar::CodecType>,
+    /// Doc-count boundary for choosing the vector-storage format on merge.
+    ///
+    /// A merge whose target segment has strictly fewer than this many
+    /// docs writes `.flatvec`; at or above this many docs writes
+    /// `.ivfvec` (clustered). Exactly one format is written per merge —
+    /// `FlatVecPlugin` and `IvfVecPlugin` short-circuit symmetrically
+    /// off this threshold.
+    #[serde(default = "default_vector_clustering_threshold")]
+    #[serde(skip_serializing_if = "is_default_vector_clustering_threshold")]
+    pub vector_clustering_threshold: usize,
 }
 
 /// Must be a function to be compatible with serde defaults
@@ -320,6 +330,14 @@ fn is_default_codec_types(types: &[columnar::CodecType]) -> bool {
     types == columnar::DEFAULT_CODEC_TYPES
 }
 
+fn default_vector_clustering_threshold() -> usize {
+    10_000
+}
+
+fn is_default_vector_clustering_threshold(threshold: &usize) -> bool {
+    *threshold == default_vector_clustering_threshold()
+}
+
 impl Default for IndexSettings {
     fn default() -> Self {
         Self {
@@ -328,6 +346,7 @@ impl Default for IndexSettings {
             docstore_blocksize: default_docstore_blocksize(),
             docstore_compress_dedicated_thread: true,
             codec_types: default_codec_types(),
+            vector_clustering_threshold: default_vector_clustering_threshold(),
         }
     }
 }
@@ -336,6 +355,12 @@ impl IndexSettings {
     /// Returns the codec types to use for u64-based column serialization.
     pub fn columnar_codec_types(&self) -> &[columnar::CodecType] {
         &self.codec_types
+    }
+
+    /// Returns the doc-count boundary at which merges switch from flat
+    /// to IVF storage. See [`IndexSettings::vector_clustering_threshold`].
+    pub fn vector_clustering_threshold(&self) -> usize {
+        self.vector_clustering_threshold
     }
 }
 
@@ -609,6 +634,7 @@ mod tests {
                 docstore_compress_dedicated_thread: true,
                 docstore_blocksize: 16_384,
                 codec_types: columnar::DEFAULT_CODEC_TYPES.to_vec(),
+                vector_clustering_threshold: 10_000,
             }
         );
         {

--- a/src/vector/ivf/mod.rs
+++ b/src/vector/ivf/mod.rs
@@ -1,0 +1,14 @@
+//! Clustering abstraction for IVF (inverted-file) vector storage.
+//!
+//! This module currently exposes only the [`IvfClusterer`] trait and its
+//! data types. An index registers a clusterer via
+//! [`IndexBuilder::ivf_clusterer`](crate::IndexBuilder::ivf_clusterer); the
+//! IVF on-disk format and the merge that consumes the clusterer land in a
+//! follow-up.
+
+mod training;
+
+pub use training::{
+    IvfCentroids, IvfClusterer, IvfMatrix, IvfMatrixView, IvfMergeSettings, IvfVectorBatch,
+    IvfVectors,
+};

--- a/src/vector/ivf/training.rs
+++ b/src/vector/ivf/training.rs
@@ -1,0 +1,93 @@
+use crate::schema::VectorOptions;
+use crate::DocId;
+
+pub trait IvfClusterer: Send + Sync + 'static {
+    fn centroid_ratio(&self) -> f32;
+
+    fn training_samples_per_centroid(&self) -> usize;
+
+    fn train(
+        &self,
+        options: &VectorOptions,
+        vectors: IvfVectors<'_>,
+        num_centroids: usize,
+    ) -> crate::Result<IvfCentroids>;
+
+    fn assign(
+        &self,
+        options: &VectorOptions,
+        vectors: IvfVectors<'_>,
+        centroids: &IvfCentroids,
+    ) -> crate::Result<Vec<u32>>;
+
+    fn assign_batch_size(&self) -> usize {
+        2048
+    }
+
+    fn merge_settings(&self, total_target_docs: usize) -> crate::Result<IvfMergeSettings> {
+        let centroid_ratio = self.centroid_ratio();
+        let training_samples_per_centroid = self.training_samples_per_centroid();
+        let assign_batch_size = self.assign_batch_size();
+
+        assert!(
+            centroid_ratio > 0.0 && centroid_ratio <= 1.0,
+            "IvfClusterer centroid_ratio must be greater than 0 and less than or equal to 1, got \
+             {centroid_ratio}"
+        );
+        assert!(
+            training_samples_per_centroid > 1,
+            "IvfClusterer training_samples_per_centroid must be greater than 1, got \
+             {training_samples_per_centroid}"
+        );
+        assert!(
+            assign_batch_size > 0,
+            "IvfClusterer assign_batch_size must be greater than 0, got {assign_batch_size}"
+        );
+
+        let num_centroids =
+            ((total_target_docs as f64) * f64::from(centroid_ratio)).ceil() as usize;
+        let num_centroids = num_centroids.clamp(1, total_target_docs);
+        Ok(IvfMergeSettings {
+            num_centroids,
+            training_samples_per_centroid,
+            assign_batch_size,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct IvfMergeSettings {
+    pub num_centroids: usize,
+    pub training_samples_per_centroid: usize,
+    pub assign_batch_size: usize,
+}
+
+#[derive(Clone, Debug)]
+pub enum IvfCentroids {
+    F32(IvfMatrix<f32>),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum IvfVectors<'a> {
+    F32(IvfVectorBatch<'a, f32>),
+}
+
+#[derive(Clone, Debug)]
+pub struct IvfMatrix<T> {
+    pub values: Vec<T>,
+    pub rows: usize,
+    pub dims: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct IvfMatrixView<'a, T> {
+    pub values: &'a [T],
+    pub rows: usize,
+    pub dims: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct IvfVectorBatch<'a, T> {
+    pub doc_ids: &'a [DocId],
+    pub matrix: IvfMatrixView<'a, T>,
+}

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -4,7 +4,9 @@
 //! [`Metric`](crate::schema::Metric), [`VectorDType`]) lives in the schema module; the
 //! element trait [`VectorElement`] and the distance kernels live here. The on-disk format
 //! lives in the [`flat`] submodule (dense full-precision layout), owned by the
-//! [`VectorPlugin`]. Top-N vector queries dispatch over it via [`VectorBackend`].
+//! [`VectorPlugin`]. Top-N vector queries dispatch over it via [`VectorBackend`]. The
+//! [`ivf`] submodule holds the clustering abstraction ([`IvfClusterer`]) used to build the
+//! partitioned/clustered accelerator at merge time.
 
 use std::io;
 
@@ -18,6 +20,7 @@ mod plugin;
 mod reader;
 
 pub mod flat;
+pub mod ivf;
 
 pub(crate) const VEC_EXT: &str = "vec";
 
@@ -25,6 +28,10 @@ pub use backend::VectorBackend;
 pub use collector::TopDocsByVectorSimilarity;
 pub use distance::{cosine, cosine_bytes, dot, dot_bytes, l2_squared, l2_squared_bytes};
 pub use flat::{FlatVecReader, FlatVecWriter, FlatVectorColumn};
+pub use ivf::{
+    IvfCentroids, IvfClusterer, IvfMatrix, IvfMatrixView, IvfMergeSettings, IvfVectorBatch,
+    IvfVectors,
+};
 pub use plugin::VectorPlugin;
 pub use reader::{VectorColumn, VectorColumnReader, VectorReader};
 


### PR DESCRIPTION
First of a two-PR stack splitting the IVF work. This PR adds **only the clustering abstraction** — no storage or merge logic.

## What's here
- `IvfClusterer` trait and its data types (`IvfCentroids`, `IvfVectors`, `IvfMatrix`/`IvfMatrixView`, `IvfVectorBatch`, `IvfMergeSettings`) in `src/vector/ivf`.
- Index integration to register and configure a clusterer:
  - `IndexBuilder::ivf_clusterer` / `Index::set_ivf_clusterer`
  - `IndexSettings::vector_clustering_threshold` (the merge cutover knob)